### PR TITLE
Remove runtime identifier from Avalonia UI dotnet publish command

### DIFF
--- a/.github/workflows/dotnet-release-combined.yml
+++ b/.github/workflows/dotnet-release-combined.yml
@@ -116,7 +116,6 @@ jobs:
           dotnet publish ./TgaBuilderAvaloniaUi/TgaBuilderAvaloniaUi.csproj `
             -c Release `
             -f net8.0 `
-            -r win-x64 `
             --self-contained false `
             /p:PublishReadyToRun=true `
             /p:PublishSingleFile=false `


### PR DESCRIPTION
Removed runtime identifier for Avalonia UI  publishing.