### PR TITLE
Set PublishReadyToRun to false for Avalonia UI

### DIFF
--- a/.github/workflows/dotnet-release-combined.yml
+++ b/.github/workflows/dotnet-release-combined.yml
@@ -117,7 +117,7 @@ jobs:
             -c Release `
             -f net8.0 `
             --self-contained false `
-            /p:PublishReadyToRun=true `
+            /p:PublishReadyToRun=false `
             /p:PublishSingleFile=false `
             -o publish/avalonia-net8
 


### PR DESCRIPTION
Changed PublishReadyToRun property to false in the release workflow.