### PR TITLE
Modularize Transition and Modifications ViewModels

### DIFF
--- a/TgaBuilderAvaloniaUi/App.DI.axaml.cs
+++ b/TgaBuilderAvaloniaUi/App.DI.axaml.cs
@@ -301,30 +301,37 @@ namespace TgaBuilderAvaloniaUi
                 mediaFactory: sp.GetRequiredService<IMediaFactory>()));
 
             services.AddTransient(sp => new TransitionAnalysisViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionPivotSmoothViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionPivotBricksViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionUnderfillingViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionEdgeViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionShadowViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionManualViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
@@ -347,14 +354,17 @@ namespace TgaBuilderAvaloniaUi
                 mediaFactory: sp.GetRequiredService<IMediaFactory>()));
 
             services.AddTransient(sp => new ModificationsBasicViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
                 presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
 
             services.AddTransient(sp => new ModificationsColorViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
                 presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
 
             services.AddTransient(sp => new ModificationsColorOverlayViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
                 presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
 

--- a/TgaBuilderAvaloniaUi/App.DI.axaml.cs
+++ b/TgaBuilderAvaloniaUi/App.DI.axaml.cs
@@ -17,6 +17,8 @@ using TgaBuilderLib.Transitions;
 using TgaBuilderLib.Modifications;
 using TgaBuilderLib.ViewModel;
 using TgaBuilderLib.ViewModel.Elements;
+using TgaBuilderLib.ViewModel.Modifications;
+using TgaBuilderLib.ViewModel.Transitions;
 using TgaBuilderLib.ViewModel.Views;
 using Avalonia;
 using Avalonia.Controls;
@@ -294,17 +296,77 @@ namespace TgaBuilderAvaloniaUi
 
                 presenter: GetBitmapFromFactory(sp, 2 * PANEL_WIDTH_INIT, PANEL_HEIGHT_INIT, true)));
 
+            // Transition child VMs
+            services.AddTransient(sp => new TransitionPresentersViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>()));
+
+            services.AddTransient(sp => new TransitionAnalysisViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionPivotSmoothViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionPivotBricksViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionUnderfillingViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionEdgeViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionShadowViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionManualViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
             services.AddTransient(sp => new TransitionViewModel(
                 mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 bitmapOperations: sp.GetRequiredService<IBitmapOperations>(),
-                mainViewModel: sp.GetRequiredService<MainViewModel>()));
+                mainViewModel: sp.GetRequiredService<MainViewModel>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>(),
+                analysis: sp.GetRequiredService<TransitionAnalysisViewModel>(),
+                pivotSmooth: sp.GetRequiredService<TransitionPivotSmoothViewModel>(),
+                pivotBricks: sp.GetRequiredService<TransitionPivotBricksViewModel>(),
+                underfilling: sp.GetRequiredService<TransitionUnderfillingViewModel>(),
+                edge: sp.GetRequiredService<TransitionEdgeViewModel>(),
+                shadow: sp.GetRequiredService<TransitionShadowViewModel>(),
+                manual: sp.GetRequiredService<TransitionManualViewModel>()));
+
+            // Modification child VMs
+            services.AddTransient(sp => new ModificationsPresentersViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>()));
+
+            services.AddTransient(sp => new ModificationsBasicViewModel(
+                modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
+                presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
+
+            services.AddTransient(sp => new ModificationsColorViewModel(
+                modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
+                presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
+
+            services.AddTransient(sp => new ModificationsColorOverlayViewModel(
+                modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
+                presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
 
             services.AddTransient(sp => new ModificationsViewModel(
                 mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
                 bitmapOperations: sp.GetRequiredService<IBitmapOperations>(),
-                mainViewModel: sp.GetRequiredService<MainViewModel>()));
+                mainViewModel: sp.GetRequiredService<MainViewModel>(),
+                presenters: sp.GetRequiredService<ModificationsPresentersViewModel>(),
+                basic: sp.GetRequiredService<ModificationsBasicViewModel>(),
+                color: sp.GetRequiredService<ModificationsColorViewModel>(),
+                colorOverlay: sp.GetRequiredService<ModificationsColorOverlayViewModel>()));
 
             services.AddSingleton(sp => new MainViewModel(
                 getViewCallback: idx => sp.GetServices<IView>().ElementAt((int)idx),

--- a/TgaBuilderAvaloniaUi/View/ModificationsWindow.axaml
+++ b/TgaBuilderAvaloniaUi/View/ModificationsWindow.axaml
@@ -170,7 +170,7 @@
                     Header="Basic"
                     IsExpanded="True"
                     HorizontalAlignment="Stretch">
-                    <local:ModificationsWindowBasicUserControl />
+                    <local:ModificationsWindowBasicUserControl DataContext="{Binding BasicVM}" />
                 </Expander>
 
                 <!-- ================================================================= -->
@@ -180,7 +180,7 @@
                     Header="Color"
                     IsExpanded="True"
                     HorizontalAlignment="Stretch">
-                    <local:ModificationsWindowColorUserControl />
+                    <local:ModificationsWindowColorUserControl DataContext="{Binding ColorVM}" />
                 </Expander>
 
                 <!-- ================================================================= -->
@@ -190,7 +190,7 @@
                     Header="Color Overlay"
                     IsExpanded="True"
                     HorizontalAlignment="Stretch">
-                    <local:ModificationsWindowColorOverlayUserControl />
+                    <local:ModificationsWindowColorOverlayUserControl DataContext="{Binding ColorOverlayVM}" />
                 </Expander>
 
             </StackPanel>

--- a/TgaBuilderAvaloniaUi/View/ModificationsWindow.axaml.cs
+++ b/TgaBuilderAvaloniaUi/View/ModificationsWindow.axaml.cs
@@ -38,7 +38,7 @@ namespace TgaBuilderAvaloniaUi.View
 
         private void InputImage_PointerMoved(object? sender, PointerEventArgs e)
         {
-            if (DataContext is ModificationsViewModel vm && vm.IsColorOverlayEyedropperMode && sender is Image image)
+            if (DataContext is ModificationsViewModel vm && vm.ColorOverlayVM.IsColorOverlayEyedropperMode && sender is Image image)
             {
                 var position = e.GetPosition(image);
                 vm.MouseOverInputCommand.Execute((X: (int)position.X, Y: (int)position.Y));
@@ -47,21 +47,21 @@ namespace TgaBuilderAvaloniaUi.View
 
         private void InputImage_PointerEntered(object? sender, PointerEventArgs e)
         {
-            if (DataContext is ModificationsViewModel vm && vm.IsColorOverlayEyedropperMode)
+            if (DataContext is ModificationsViewModel vm && vm.ColorOverlayVM.IsColorOverlayEyedropperMode)
                 this.Cursor = CursorProvider.EyedropperCursor;
         }
 
         private void InputImage_PointerExited(object? sender, PointerEventArgs e)
         {
-            if (DataContext is ModificationsViewModel vm && vm.IsColorOverlayEyedropperMode)
+            if (DataContext is ModificationsViewModel vm && vm.ColorOverlayVM.IsColorOverlayEyedropperMode)
                 this.Cursor = CursorProvider.DefaultCursor;
         }
 
         private void InputImage_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if (DataContext is ModificationsViewModel vm && vm.IsColorOverlayEyedropperMode)
+            if (DataContext is ModificationsViewModel vm && vm.ColorOverlayVM.IsColorOverlayEyedropperMode)
             {
-                vm.IsColorOverlayEyedropperMode = false;
+                vm.ColorOverlayVM.IsColorOverlayEyedropperMode = false;
                 this.Cursor = CursorProvider.DefaultCursor;
             }
         }

--- a/TgaBuilderAvaloniaUi/View/ModificationsWindowBasicUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/ModificationsWindowBasicUserControl.axaml
@@ -2,10 +2,10 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Modifications;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             x:DataType="viewmodel:ModificationsViewModel"
+             x:DataType="viewmodel:ModificationsBasicViewModel"
              x:CompileBindings="False">
                     <StackPanel
                         Margin="4,4,4,6">

--- a/TgaBuilderAvaloniaUi/View/ModificationsWindowColorOverlayUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/ModificationsWindowColorOverlayUserControl.axaml
@@ -2,10 +2,10 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Modifications;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
              xmlns:converter="clr-namespace:TgaBuilderAvaloniaUi.Converters"
-             x:DataType="viewmodel:ModificationsViewModel"
+             x:DataType="viewmodel:ModificationsColorOverlayViewModel"
              x:CompileBindings="False">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/TgaBuilderAvaloniaUi/View/ModificationsWindowColorUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/ModificationsWindowColorUserControl.axaml
@@ -2,10 +2,10 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Modifications;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             x:DataType="viewmodel:ModificationsViewModel"
+             x:DataType="viewmodel:ModificationsColorViewModel"
              x:CompileBindings="False"
              xmlns:converter="clr-namespace:TgaBuilderAvaloniaUi.Converters">
     <UserControl.Resources>

--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml
@@ -287,7 +287,8 @@
             <!-- Smooth mode: Hardness / Widening / Shift sliders -->
             <local:TransitionWindowSmoothUserControl
                 Grid.Row="0"
-                IsVisible="{Binding IsSmoothMode}" />
+                DataContext="{Binding PivotSmooth}"
+                IsVisible="{Binding $parent[Window].DataContext.IsSmoothMode}" />
 
             <!-- Brick mode: scrollable expanders -->
             <ScrollViewer
@@ -325,7 +326,7 @@
                                     Height="26" />
                             </StackPanel>
                         </Expander.Header>
-                        <local:TransitionWindowAnalysisUserControl />
+                        <local:TransitionWindowAnalysisUserControl DataContext="{Binding Analysis}" />
                     </Expander>
 
                     <!-- Parameter Section: Pivot Boundaries -->
@@ -333,7 +334,7 @@
                         Header="Pivot"
                         IsExpanded="True"
                         HorizontalAlignment="Stretch">
-                        <local:TransitionWindowPivotUserControl />
+                        <local:TransitionWindowPivotUserControl DataContext="{Binding PivotBricks}" />
                     </Expander>
 
                     <!-- Parameter Section: Edge Blending -->
@@ -341,7 +342,7 @@
                          Header="Edge"
                          IsExpanded="True"
                          HorizontalAlignment="Stretch">
-                         <local:TransitionWindowEdgeUserControl />
+                         <local:TransitionWindowEdgeUserControl DataContext="{Binding Edge}" />
                      </Expander>
 
                      <!-- Parameter Section: Shadow -->
@@ -349,7 +350,7 @@
                          Header="Shadow"
                          IsExpanded="True"
                          HorizontalAlignment="Stretch">
-                         <local:TransitionWindowShadowUserControl />
+                         <local:TransitionWindowShadowUserControl DataContext="{Binding Shadow}" />
                      </Expander>
 
                       <!-- Parameter Section: Underfilling -->
@@ -357,7 +358,7 @@
                           Header="Underfilling"
                           IsExpanded="True"
                           HorizontalAlignment="Stretch">
-                         <local:TransitionWindowUnderfillingUserControl />
+                         <local:TransitionWindowUnderfillingUserControl DataContext="{Binding Underfilling}" />
                      </Expander>
 
                      <!-- Parameter Section: Manual -->
@@ -365,7 +366,7 @@
                          Header="Manual"
                          IsExpanded="True"
                          HorizontalAlignment="Stretch">
-                         <local:TransitionWindowManualUserControl />
+                         <local:TransitionWindowManualUserControl DataContext="{Binding Manual}" />
                      </Expander>
                  </StackPanel>
              </ScrollViewer>

--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -78,22 +78,22 @@ namespace TgaBuilderAvaloniaUi.View
 
         private void Image1_PointerEntered(object? sender, PointerEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
                 this.Cursor = CursorProvider.EyedropperCursor;
         }
 
         private void Image1_PointerExited(object? sender, PointerEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
                 this.Cursor = CursorProvider.DefaultCursor;
         }
 
         private void Image1_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
             {
-                vm.IsEyedropperMode = false;
-                vm.IsShadowEyedropperMode = false;
+                vm.Edge.IsEyedropperMode = false;
+                vm.Shadow.IsShadowEyedropperMode = false;
                 this.Cursor = CursorProvider.DefaultCursor;
             }
         }
@@ -105,29 +105,29 @@ namespace TgaBuilderAvaloniaUi.View
 
         private void Image2_PointerEntered(object? sender, PointerEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
                 this.Cursor = CursorProvider.EyedropperCursor;
         }
 
         private void Image2_PointerExited(object? sender, PointerEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
                 this.Cursor = CursorProvider.DefaultCursor;
         }
 
         private void Image2_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
             {
-                vm.IsEyedropperMode = false;
-                vm.IsShadowEyedropperMode = false;
+                vm.Edge.IsEyedropperMode = false;
+                vm.Shadow.IsShadowEyedropperMode = false;
                 this.Cursor = CursorProvider.DefaultCursor;
             }
         }
 
         private void DoEyedropperMouseMove(Image image, PointerEventArgs e, int imageNum)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
             {
                 var position = e.GetPosition(image);
                 vm.MouseOverCommand.Execute((X: (int)position.X, Y: (int)position.Y, imageNum));
@@ -139,7 +139,7 @@ namespace TgaBuilderAvaloniaUi.View
             if (DataContext is not TransitionViewModel vm)
                 return;
 
-            if (!vm.IsExplicitTileVisibilityDrawMode && !vm.IsExplicitTileVisibilityEraseMode)
+            if (!vm.Manual.IsExplicitTileVisibilityDrawMode && !vm.Manual.IsExplicitTileVisibilityEraseMode)
                 return;
 
             if (vm.RequestLabelIndicatorCommand is ICommand requestLabelIndicatorCommand)
@@ -161,7 +161,7 @@ namespace TgaBuilderAvaloniaUi.View
             if (DataContext is not TransitionViewModel vm)
                 return;
 
-            if (!vm.IsExplicitTileVisibilityDrawMode && !vm.IsExplicitTileVisibilityEraseMode)
+            if (!vm.Manual.IsExplicitTileVisibilityDrawMode && !vm.Manual.IsExplicitTileVisibilityEraseMode)
                 return;
 
             vm.IsIndicatorMapVisible = true;
@@ -172,7 +172,7 @@ namespace TgaBuilderAvaloniaUi.View
             if (DataContext is not TransitionViewModel vm)
                 return;
 
-            if (!vm.IsExplicitTileVisibilityDrawMode && !vm.IsExplicitTileVisibilityEraseMode)
+            if (!vm.Manual.IsExplicitTileVisibilityDrawMode && !vm.Manual.IsExplicitTileVisibilityEraseMode)
                 return;
 
             vm.IsIndicatorMapVisible = false;
@@ -183,7 +183,7 @@ namespace TgaBuilderAvaloniaUi.View
             if (DataContext is not TransitionViewModel vm)
                 return;
 
-            if (!vm.IsExplicitTileVisibilityDrawMode && !vm.IsExplicitTileVisibilityEraseMode)
+            if (!vm.Manual.IsExplicitTileVisibilityDrawMode && !vm.Manual.IsExplicitTileVisibilityEraseMode)
                 return;
 
             if (e.GetCurrentPoint(ResultImage).Properties.IsLeftButtonPressed

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowAnalysisUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowAnalysisUserControl.axaml
@@ -2,10 +2,10 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             x:DataType="viewmodel:TransitionViewModel"
+             x:DataType="viewmodel:TransitionAnalysisViewModel"
              x:CompileBindings="False">
       <UserControl.Resources>
             <ResourceDictionary>
@@ -34,7 +34,7 @@
                       BorderThickness="0"
                       Background="Transparent"
                       TextBlock.TextTrimming="CharacterEllipsis"
-                      SelectedIndex="{Binding SelectedSegmentationMethodIndex}"
+                      SelectedIndex="{Binding Analysis.SelectedSegmentationMethodIndex}"
                       ap:MouseOverInfoAP.InfoText="Segmentation method: algorithm used to identify brick regions">
                   <ComboBoxItem Content="Felzenszwalb" />
                   <ComboBoxItem Content="SLIC" />
@@ -52,8 +52,8 @@
                                              Width="36"
                                              Height="36"
                                              Icon="{StaticResource table}"
-                                             IsChecked="{Binding InvertGrayscale}"
-                                             IsVisible="{Binding ShowGrayBasedSegmentationInputs}"
+                                             IsChecked="{Binding Analysis.InvertGrayscale}"
+                                             IsVisible="{Binding Analysis.ShowGrayBasedSegmentationInputs}"
                                              ap:MouseOverInfoAP.InfoText="Invert Grayscale: Recommended for textures in which the joints are brighter than the tiles (e.g. sand, snow in the joints)" />
 
                   <!-- Row 3: Filter Selector -->
@@ -70,7 +70,7 @@
                             BorderThickness="0"
                             Background="Transparent"
                             TextBlock.TextTrimming="CharacterEllipsis"
-                            SelectedIndex="{Binding SelectedFilterIndex}"
+                            SelectedIndex="{Binding Analysis.SelectedFilterIndex}"
                             ap:MouseOverInfoAP.InfoText="Filter: pre-processing filter applied to the result image">
                         <ComboBoxItem Content="None" />
                         <ComboBoxItem Content="Box Blur" />
@@ -92,24 +92,24 @@
                        FontSize="18"
                        Margin="5,0,0,0"
                        Text="σ"
-                       IsVisible="{Binding ShowBilateralSigma}"
+                       IsVisible="{Binding Analysis.ShowBilateralSigma}"
                        ap:MouseOverInfoAP.InfoText="Bilateral sigma: color similarity weighting strength" />
             <elements:MouseWheelSlider Grid.Row="3" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding BilateralSigma}"
+                                       ToolTip.Tip="{Binding Analysis.BilateralSigma}"
                                        Maximum="100"
                                        Minimum="0.1"
                                        SmallChange="0.1"
-                                       Value="{Binding BilateralSigma}"
-                                       IsVisible="{Binding ShowBilateralSigma}"
+                                       Value="{Binding Analysis.BilateralSigma}"
+                                       IsVisible="{Binding Analysis.ShowBilateralSigma}"
                                        ap:MouseOverInfoAP.InfoText="Bilateral sigma: color similarity weighting strength" />
             <TextBlock Grid.Row="3" Grid.Column="2"
                        VerticalAlignment="Center"
                        Foreground="{DynamicResource IconFillBrush}"
                        FontSize="18"
                        Text=" Σ"
-                       IsVisible="{Binding ShowBilateralSigma}"
+                       IsVisible="{Binding Analysis.ShowBilateralSigma}"
                        ap:MouseOverInfoAP.InfoText="Bilateral sigma: color similarity weighting strength" />
 
             <!-- Row 4: Gaussian Sigma Slider -->
@@ -119,24 +119,24 @@
                        FontSize="18"
                        Margin="5,0,0,0"
                        Text="σ"
-                       IsVisible="{Binding ShowGaussianSigma}"
+                       IsVisible="{Binding Analysis.ShowGaussianSigma}"
                        ap:MouseOverInfoAP.InfoText="Gaussian sigma: blur radius weighting strength" />
             <elements:MouseWheelSlider Grid.Row="4" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding GaussianSigma}"
+                                       ToolTip.Tip="{Binding Analysis.GaussianSigma}"
                                        Maximum="20"
                                        Minimum="0.1"
                                        SmallChange="0.1"
-                                       Value="{Binding GaussianSigma}"
-                                       IsVisible="{Binding ShowGaussianSigma}"
+                                       Value="{Binding Analysis.GaussianSigma}"
+                                       IsVisible="{Binding Analysis.ShowGaussianSigma}"
                                        ap:MouseOverInfoAP.InfoText="Gaussian sigma: blur radius weighting strength" />
             <TextBlock Grid.Row="4" Grid.Column="2"
                        VerticalAlignment="Center"
                        Foreground="{DynamicResource IconFillBrush}"
                        FontSize="18"
                        Text=" Σ"
-                       IsVisible="{Binding ShowGaussianSigma}"
+                       IsVisible="{Binding Analysis.ShowGaussianSigma}"
                        ap:MouseOverInfoAP.InfoText="Gaussian sigma: blur radius weighting strength" />
 
             <!-- Row 5: Marker Count Slider -->
@@ -147,26 +147,26 @@
                        TextElement.FontSize="10"
                        Margin="10,5,0,5"
                        Text="#"
-                       IsVisible="{Binding ShowWatershedBasedSegmentationInputs}"
+                       IsVisible="{Binding Analysis.ShowWatershedBasedSegmentationInputs}"
                        ap:MouseOverInfoAP.InfoText="Marker Count: count of the seed markers for watershed segmentation (1 - 256)" />
             <elements:MouseWheelSlider Grid.Row="5" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding MarkerCount}"
+                                       ToolTip.Tip="{Binding Analysis.MarkerCount}"
                                        IsSnapToTickEnabled="True"
                                        TickFrequency="1"
                                        Maximum="256"
                                        Minimum="1"
                                        SmallChange="1"
-                                       Value="{Binding MarkerCount}"
-                                       IsVisible="{Binding ShowWatershedBasedSegmentationInputs}"
+                                       Value="{Binding Analysis.MarkerCount}"
+                                       IsVisible="{Binding Analysis.ShowWatershedBasedSegmentationInputs}"
                                        ap:MouseOverInfoAP.InfoText="Marker Count: count of the seed markers for watershed segmentation (1 - 256)" />
             <TextBlock Grid.Row="5" Grid.Column="2"
                        VerticalAlignment="Center"
                        Foreground="{DynamicResource IconFillBrush}"
                        Text=" #"
                        TextElement.FontSize="20"
-                       IsVisible="{Binding ShowWatershedBasedSegmentationInputs}"
+                       IsVisible="{Binding Analysis.ShowWatershedBasedSegmentationInputs}"
                        ap:MouseOverInfoAP.InfoText="Marker Count: count of the seed markers for watershed segmentation (1 - 256)" />
 
             <!-- Row 6: Marker Radius Slider -->
@@ -178,19 +178,19 @@
                   Stretch="Uniform"
                   Margin="5,0,0,0"
                   Data="{StaticResource circle_small}"
-                  IsVisible="{Binding ShowGridFittingSegmentationInputs}"
+                  IsVisible="{Binding Analysis.ShowGridFittingSegmentationInputs}"
                   ap:MouseOverInfoAP.InfoText="Marker Radius: size of the seed markers for segmentation (1 = small, 20 = large)" />
             <elements:MouseWheelSlider Grid.Row="6" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding MarkerRadius}"
+                                       ToolTip.Tip="{Binding Analysis.MarkerRadius}"
                                        IsSnapToTickEnabled="True"
                                        TickFrequency="1"
                                        Maximum="20"
                                        Minimum="1"
                                        SmallChange="1"
-                                       Value="{Binding MarkerRadius}"
-                                       IsVisible="{Binding ShowGridFittingSegmentationInputs}"
+                                       Value="{Binding Analysis.MarkerRadius}"
+                                       IsVisible="{Binding Analysis.ShowGridFittingSegmentationInputs}"
                                        ap:MouseOverInfoAP.InfoText="Marker Radius: size of the seed markers for segmentation (1 = small, 20 = large)" />
             <Path Grid.Row="6" Grid.Column="2"
                   VerticalAlignment="Center"
@@ -199,7 +199,7 @@
                   Height="14"
                   Stretch="Uniform"
                   Data="{StaticResource circle}"
-                  IsVisible="{Binding ShowGridFittingSegmentationInputs}"
+                  IsVisible="{Binding Analysis.ShowGridFittingSegmentationInputs}"
                   ap:MouseOverInfoAP.InfoText="Marker Radius: size of the seed markers for segmentation (1 = small, 20 = large)" />
 
             <!-- Row 7: Felzenszwalb Min Size Slider -->
@@ -211,19 +211,19 @@
                   Stretch="Uniform"
                   Margin="5,0,0,0"
                   Data="{StaticResource circle_small}"
-                  IsVisible="{Binding ShowFelzenszwalbParameters}"
+                  IsVisible="{Binding Analysis.ShowFelzenszwalbParameters}"
                   ap:MouseOverInfoAP.InfoText="Felzenszwalb min size: minimum component size before region merging" />
             <elements:MouseWheelSlider Grid.Row="7" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding FelzenszwalbMinSize}"
+                                       ToolTip.Tip="{Binding Analysis.FelzenszwalbMinSize}"
                                        IsSnapToTickEnabled="True"
                                        TickFrequency="1"
                                        Maximum="500"
                                        Minimum="1"
                                        SmallChange="1"
-                                       Value="{Binding FelzenszwalbMinSize}"
-                                       IsVisible="{Binding ShowFelzenszwalbParameters}"
+                                       Value="{Binding Analysis.FelzenszwalbMinSize}"
+                                       IsVisible="{Binding Analysis.ShowFelzenszwalbParameters}"
                                        ap:MouseOverInfoAP.InfoText="Felzenszwalb min size: minimum component size before region merging" />
             <Path Grid.Row="7" Grid.Column="2"
                   VerticalAlignment="Center"
@@ -232,7 +232,7 @@
                   Height="14"
                   Stretch="Uniform"
                   Data="{StaticResource circle}"
-                  IsVisible="{Binding ShowFelzenszwalbParameters}"
+                  IsVisible="{Binding Analysis.ShowFelzenszwalbParameters}"
                   ap:MouseOverInfoAP.InfoText="Felzenszwalb min size: minimum component size before region merging" />
 
             <!-- Row 8: Felzenszwalb Scale Slider -->
@@ -244,17 +244,17 @@
                   Stretch="Uniform"
                   Margin="5,0,0,0"
                   Data="{StaticResource scale_fit}"
-                  IsVisible="{Binding ShowFelzenszwalbParameters}"
+                  IsVisible="{Binding Analysis.ShowFelzenszwalbParameters}"
                   ap:MouseOverInfoAP.InfoText="Felzenszwalb scale: merge tolerance scale factor" />
             <elements:MouseWheelSlider Grid.Row="8" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding FelzenszwalbScale}"
+                                       ToolTip.Tip="{Binding Analysis.FelzenszwalbScale}"
                                        Maximum="500"
                                        Minimum="1"
                                        SmallChange="1"
-                                       Value="{Binding FelzenszwalbScale}"
-                                       IsVisible="{Binding ShowFelzenszwalbParameters}"
+                                       Value="{Binding Analysis.FelzenszwalbScale}"
+                                       IsVisible="{Binding Analysis.ShowFelzenszwalbParameters}"
                                        ap:MouseOverInfoAP.InfoText="Felzenszwalb scale: merge tolerance scale factor" />
             <Path Grid.Row="8" Grid.Column="2"
                   VerticalAlignment="Center"
@@ -263,7 +263,7 @@
                   Height="14"
                   Stretch="Uniform"
                   Data="{StaticResource scale_fill}"
-                  IsVisible="{Binding ShowFelzenszwalbParameters}"
+                  IsVisible="{Binding Analysis.ShowFelzenszwalbParameters}"
                   ap:MouseOverInfoAP.InfoText="Felzenszwalb scale: merge tolerance scale factor" />
 
             <!-- Row 9: SLIC Segment Count Slider -->
@@ -275,19 +275,19 @@
                   Stretch="Uniform"
                   Margin="5,0,0,0"
                   Data="{StaticResource square_simple}"
-                  IsVisible="{Binding ShowSlicParameters}"
+                  IsVisible="{Binding Analysis.ShowSlicParameters}"
                   ap:MouseOverInfoAP.InfoText="SLIC segment count: target number of superpixels" />
             <elements:MouseWheelSlider Grid.Row="9" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding SlicSegmentCount}"
+                                       ToolTip.Tip="{Binding Analysis.SlicSegmentCount}"
                                        IsSnapToTickEnabled="True"
                                        TickFrequency="1"
                                        Maximum="2000"
                                        Minimum="1"
                                        SmallChange="1"
-                                       Value="{Binding SlicSegmentCount}"
-                                       IsVisible="{Binding ShowSlicParameters}"
+                                       Value="{Binding Analysis.SlicSegmentCount}"
+                                       IsVisible="{Binding Analysis.ShowSlicParameters}"
                                        ap:MouseOverInfoAP.InfoText="SLIC segment count: target number of superpixels" />
             <Path Grid.Row="9" Grid.Column="2"
                   VerticalAlignment="Center"
@@ -296,7 +296,7 @@
                   Height="14"
                   Stretch="Uniform"
                   Data="{StaticResource grid}"
-                  IsVisible="{Binding ShowSlicParameters}"
+                  IsVisible="{Binding Analysis.ShowSlicParameters}"
                   ap:MouseOverInfoAP.InfoText="SLIC segment count: target number of superpixels" />
 
             <!-- Row 10: SLIC Compactness Slider -->
@@ -308,17 +308,17 @@
                   Stretch="Uniform"
                   Margin="5,0,0,0"
                   Data="{StaticResource scale_fit}"
-                  IsVisible="{Binding ShowSlicParameters}"
+                  IsVisible="{Binding Analysis.ShowSlicParameters}"
                   ap:MouseOverInfoAP.InfoText="SLIC compactness: trade-off between color similarity and spatial regularity" />
             <elements:MouseWheelSlider Grid.Row="10" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding SlicCompactness}"
+                                       ToolTip.Tip="{Binding Analysis.SlicCompactness}"
                                        Maximum="50"
                                        Minimum="0.1"
                                        SmallChange="0.1"
-                                       Value="{Binding SlicCompactness}"
-                                       IsVisible="{Binding ShowSlicParameters}"
+                                       Value="{Binding Analysis.SlicCompactness}"
+                                       IsVisible="{Binding Analysis.ShowSlicParameters}"
                                        ap:MouseOverInfoAP.InfoText="SLIC compactness: trade-off between color similarity and spatial regularity" />
             <Path Grid.Row="10" Grid.Column="2"
                   VerticalAlignment="Center"
@@ -327,7 +327,7 @@
                   Height="14"
                   Stretch="Uniform"
                   Data="{StaticResource scale_fill}"
-                  IsVisible="{Binding ShowSlicParameters}"
+                  IsVisible="{Binding Analysis.ShowSlicParameters}"
                   ap:MouseOverInfoAP.InfoText="SLIC compactness: trade-off between color similarity and spatial regularity" />
 
             <!-- Row 11: Quickshift Max Distance Slider -->
@@ -339,19 +339,19 @@
                   Stretch="Uniform"
                   Margin="5,0,0,0"
                   Data="{StaticResource arrow_minimize}"
-                  IsVisible="{Binding ShowQuickshiftParameters}"
+                  IsVisible="{Binding Analysis.ShowQuickshiftParameters}"
                   ap:MouseOverInfoAP.InfoText="Quickshift max distance: maximum local growth distance from seed" />
             <elements:MouseWheelSlider Grid.Row="11" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding QuickshiftMaxDist}"
+                                       ToolTip.Tip="{Binding Analysis.QuickshiftMaxDist}"
                                        IsSnapToTickEnabled="True"
                                        TickFrequency="1"
                                        Maximum="50"
                                        Minimum="1"
                                        SmallChange="1"
-                                       Value="{Binding QuickshiftMaxDist}"
-                                       IsVisible="{Binding ShowQuickshiftParameters}"
+                                       Value="{Binding Analysis.QuickshiftMaxDist}"
+                                       IsVisible="{Binding Analysis.ShowQuickshiftParameters}"
                                        ap:MouseOverInfoAP.InfoText="Quickshift max distance: maximum local growth distance from seed" />
             <Path Grid.Row="11" Grid.Column="2"
                   VerticalAlignment="Center"
@@ -360,7 +360,7 @@
                   Height="14"
                   Stretch="Uniform"
                   Data="{StaticResource arrow_maximize}"
-                  IsVisible="{Binding ShowQuickshiftParameters}"
+                  IsVisible="{Binding Analysis.ShowQuickshiftParameters}"
                   ap:MouseOverInfoAP.InfoText="Quickshift max distance: maximum local growth distance from seed" />
 
             <!-- Row 12: Quickshift Ratio Slider -->
@@ -370,24 +370,24 @@
                        Margin="5,0,0,0"
                        Text="≠"
                        TextElement.FontSize="22"
-                       IsVisible="{Binding ShowQuickshiftParameters}"
+                       IsVisible="{Binding Analysis.ShowQuickshiftParameters}"
                        ap:MouseOverInfoAP.InfoText="Quickshift ratio: color similarity threshold scaling" />
             <elements:MouseWheelSlider Grid.Row="12" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding QuickshiftRatio}"
+                                       ToolTip.Tip="{Binding Analysis.QuickshiftRatio}"
                                        Maximum="5"
                                        Minimum="0.1"
                                        SmallChange="0.1"
-                                       Value="{Binding QuickshiftRatio}"
-                                       IsVisible="{Binding ShowQuickshiftParameters}"
+                                       Value="{Binding Analysis.QuickshiftRatio}"
+                                       IsVisible="{Binding Analysis.ShowQuickshiftParameters}"
                                        ap:MouseOverInfoAP.InfoText="Quickshift ratio: color similarity threshold scaling" />
             <TextBlock Grid.Row="12" Grid.Column="2"
                        VerticalAlignment="Center"
                        Foreground="{DynamicResource IconFillBrush}"
                        Text="="
                        TextElement.FontSize="22"
-                       IsVisible="{Binding ShowQuickshiftParameters}"
+                       IsVisible="{Binding Analysis.ShowQuickshiftParameters}"
                        ap:MouseOverInfoAP.InfoText="Quickshift ratio: color similarity threshold scaling" />
 
             <!-- Row 13: Grid Fit Angle Slider -->
@@ -400,17 +400,17 @@
             Height="14"
             Stretch="Uniform"
             ap:MouseOverInfoAP.InfoText="Grid fit angle: angle for grid fitting segmentation"
-            IsVisible="{Binding ShowGridFittingSegmentationInputs}"
+            IsVisible="{Binding Analysis.ShowGridFittingSegmentationInputs}"
             Data="{StaticResource arrow_rotate_counterclockwise}" />
             <elements:MouseWheelSlider Grid.Row="13" Grid.Column="1"
                                        Margin="5,0"
                                        VerticalAlignment="Center"
-                                       ToolTip.Tip="{Binding GridFitAngle}"
+                                       ToolTip.Tip="{Binding Analysis.GridFitAngle}"
                                        Maximum="90"
                                        Minimum="-90"
                                        SmallChange="0.1"
-                                       Value="{Binding GridFitAngle}"
-                                       IsVisible="{Binding ShowGridFittingSegmentationInputs}"
+                                       Value="{Binding Analysis.GridFitAngle}"
+                                       IsVisible="{Binding Analysis.ShowGridFittingSegmentationInputs}"
                                        ap:MouseOverInfoAP.InfoText="Grid fit angle: angle for grid fitting segmentation" />
             <Path
             Grid.Row="13" Grid.Column="2"
@@ -419,7 +419,7 @@
             Width="14"
             Height="14"
             Stretch="Uniform"
-            IsVisible="{Binding ShowGridFittingSegmentationInputs}"
+            IsVisible="{Binding Analysis.ShowGridFittingSegmentationInputs}"
             ap:MouseOverInfoAP.InfoText="Grid fit angle: angle for grid fitting segmentation"
             Data="{StaticResource arrow_rotate_clockwise}" />
 

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowEdgeUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowEdgeUserControl.axaml
@@ -1,11 +1,11 @@
-<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowEdgeUserControl"
+﻿<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowEdgeUserControl"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             x:DataType="viewmodel:TransitionViewModel"
+             x:DataType="viewmodel:TransitionEdgeViewModel"
              x:CompileBindings="False"
              xmlns:converter="clr-namespace:TgaBuilderAvaloniaUi.Converters">
     <UserControl.Resources>
@@ -26,7 +26,7 @@
                                     Width="36"
                                     Height="36"
                                     Padding="-6,0,15,0"
-                                    IsChecked="{Binding IsEyedropperMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                                    IsChecked="{Binding Edge.IsEyedropperMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                     ap:MouseOverInfoAP.InfoText="Pick edge color from image">
                                     <ToggleButton.Content>
                                         <Path
@@ -43,7 +43,7 @@
                                 <ColorPicker
                                     x:Name="SourceColorPicker"
                                     ap:MouseOverInfoAP.InfoText="Choose edge color used for edge blending"
-                                    Color="{Binding EdgeColor, Converter={StaticResource ColorStructToMediaColor}, Mode=TwoWay}" />
+                                    Color="{Binding Edge.EdgeColor, Converter={StaticResource ColorStructToMediaColor}, Mode=TwoWay}" />
                             </StackPanel>
 
                             <DockPanel
@@ -62,8 +62,8 @@
                                     Background="Transparent"
                                     VerticalAlignment="Center"
                                     TextBlock.TextTrimming="CharacterEllipsis"
-                                    ItemsSource="{Binding EdgeBlendModes}"
-                                    SelectedItem="{Binding BlendMode, Mode=TwoWay}" />
+                                    ItemsSource="{Binding Edge.EdgeBlendModes}"
+                                    SelectedItem="{Binding Edge.BlendMode, Mode=TwoWay}" />
                             </DockPanel>
 
                             <DockPanel
@@ -86,13 +86,13 @@
                                 <elements:MouseWheelSlider
                                     Margin="5,0"
                                     VerticalAlignment="Center"
-                                    ToolTip.Tip="{Binding EdgeWidth}"
+                                    ToolTip.Tip="{Binding Edge.EdgeWidth}"
                                     IsSnapToTickEnabled="True"
                                     TickFrequency="1"
                                     Maximum="12"
                                     Minimum="0"
                                     SmallChange="1"
-                                    Value="{Binding EdgeWidth}" />
+                                    Value="{Binding Edge.EdgeWidth}" />
                             </DockPanel>
                         </StackPanel>
                     

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowManualUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowManualUserControl.axaml
@@ -1,10 +1,10 @@
-<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowManualUserControl"
+﻿<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowManualUserControl"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
-             x:DataType="viewmodel:TransitionViewModel"
+             x:DataType="viewmodel:TransitionManualViewModel"
              x:CompileBindings="False">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -43,7 +43,7 @@
                 MinWidth="36"
                 Icon="{StaticResource backspace}"
                 ap:MouseOverInfoAP.InfoText="Reset Explicit Visibility"
-                Command="{Binding ResetExplicitVisibilityCommand}" />
+                Command="{Binding $parent[Window].DataContext.ResetExplicitVisibilityCommand}" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowPivotUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowPivotUserControl.axaml
@@ -1,11 +1,11 @@
-<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowPivotUserControl"
+﻿<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowPivotUserControl"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             x:DataType="viewmodel:TransitionViewModel"
+             x:DataType="viewmodel:TransitionPivotBricksViewModel"
              x:CompileBindings="False">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -29,7 +29,7 @@
             MinWidth="36"
             Icon="{StaticResource flip_horizontal}"
             ap:MouseOverInfoAP.InfoText="Reverse the pivot direction"
-            IsChecked="{Binding ReversePivot}" />
+            IsChecked="{Binding PivotBricks.ReversePivot}" />
         <elements:IconToggleButton
             x:Name="ProtectEdgesToggleButton"
             Classes="outlined"
@@ -38,7 +38,7 @@
             MinWidth="36"
             Icon="{StaticResource shield}"
             ap:MouseOverInfoAP.InfoText="Protect Edges: Enabling ensures that tile texture bordering edges contains tiles and background bordering edges do not contain tiles."
-            IsChecked="{Binding ProtectEdges}" />
+            IsChecked="{Binding PivotBricks.ProtectEdges}" />
         <elements:IconToggleButton
             x:Name="SliceCornersToggleButton"
             Classes="outlined"
@@ -46,7 +46,7 @@
             ap:MouseOverInfoAP.InfoText="Slice Corners: enable/disable slicing of corner tiles"
             Icon="{StaticResource cut}"
             IsEnabled="{Binding #ProtectEdgesToggleButton.IsChecked}"
-            IsChecked="{Binding SliceCornerTiles}" />
+            IsChecked="{Binding PivotBricks.SliceCornerTiles}" />
     </StackPanel>
 
     <!-- Row 2: Widening Value Slider -->
@@ -75,11 +75,11 @@
     <elements:MouseWheelSlider Grid.Row="1" Grid.Column="1"
                                Margin="5,0"
                                VerticalAlignment="Center"
-                               ToolTip.Tip="{Binding WideningValue}"
+                               ToolTip.Tip="{Binding PivotBricks.WideningValue}"
                                Maximum="1"
                                Minimum="0"
                                SmallChange="0.01"
-                               Value="{Binding WideningValue}"
+                               Value="{Binding PivotBricks.WideningValue}"
                                ap:MouseOverInfoAP.InfoText="Widening: At 0, the transition starts as a point and becomes a wider plateau as values approach 1." />
     <Grid Grid.Row="1" Grid.Column="2"
           VerticalAlignment="Top"
@@ -130,11 +130,11 @@
     <elements:MouseWheelSlider Grid.Row="2" Grid.Column="1"
                                Margin="5,0"
                                VerticalAlignment="Center"
-                               ToolTip.Tip="{Binding ShiftValue}"
+                               ToolTip.Tip="{Binding PivotBricks.ShiftValue}"
                                Maximum="1"
                                Minimum="-1"
                                SmallChange="0.01"
-                               Value="{Binding ShiftValue}"
+                               Value="{Binding PivotBricks.ShiftValue}"
                                ap:MouseOverInfoAP.InfoText="Shift: moves the transition front point or plateau left (negative) or right (positive)" />
     <Grid Grid.Row="2" Grid.Column="2"
           VerticalAlignment="Top"

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowShadowUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowShadowUserControl.axaml
@@ -1,10 +1,10 @@
-<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowShadowUserControl"
+﻿<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowShadowUserControl"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
-             x:DataType="viewmodel:TransitionViewModel"
+             x:DataType="viewmodel:TransitionShadowViewModel"
              x:CompileBindings="False"
              xmlns:converter="clr-namespace:TgaBuilderAvaloniaUi.Converters">
     <UserControl.Resources>
@@ -25,7 +25,7 @@
                 Width="36"
                 Height="36"
                 Padding="-6,0,15,0"
-                IsChecked="{Binding IsShadowEyedropperMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                IsChecked="{Binding Shadow.IsShadowEyedropperMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                 ap:MouseOverInfoAP.InfoText="Pick shadow color from image">
                 <ToggleButton.Content>
                     <Path
@@ -42,7 +42,7 @@
             <ColorPicker
                 x:Name="ShadowColorPicker"
                 ap:MouseOverInfoAP.InfoText="Choose shadow color drawn over background behind tile borders"
-                Color="{Binding ShadowColor, Converter={StaticResource ColorStructToMediaColor}, Mode=TwoWay}" />
+                Color="{Binding Shadow.ShadowColor, Converter={StaticResource ColorStructToMediaColor}, Mode=TwoWay}" />
         </StackPanel>
 
         <DockPanel
@@ -66,13 +66,13 @@
             <elements:MouseWheelSlider
                 Margin="5,0"
                 VerticalAlignment="Center"
-                ToolTip.Tip="{Binding ShadowSize}"
+                ToolTip.Tip="{Binding Shadow.ShadowSize}"
                 IsSnapToTickEnabled="True"
                 TickFrequency="1"
                 Maximum="32"
                 Minimum="0"
                 SmallChange="1"
-                Value="{Binding ShadowSize}" />
+                Value="{Binding Shadow.ShadowSize}" />
         </DockPanel>
 
         <DockPanel
@@ -96,13 +96,13 @@
             <elements:MouseWheelSlider
                 Margin="5,0"
                 VerticalAlignment="Center"
-                ToolTip.Tip="{Binding ShadowHardness}"
+                ToolTip.Tip="{Binding Shadow.ShadowHardness}"
                 IsSnapToTickEnabled="True"
                 TickFrequency="1"
                 Maximum="100"
                 Minimum="0"
                 SmallChange="1"
-                Value="{Binding ShadowHardness}" />
+                Value="{Binding Shadow.ShadowHardness}" />
         </DockPanel>
     </StackPanel>
 </UserControl>

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowSmoothUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowSmoothUserControl.axaml
@@ -1,15 +1,14 @@
-<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowSmoothUserControl"
+﻿<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowSmoothUserControl"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             x:DataType="viewmodel:TransitionViewModel"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
+             x:DataType="viewmodel:TransitionPivotSmoothViewModel"
              x:CompileBindings="False"
              >
             <StackPanel
-                Grid.Row="0"
-                IsVisible="{Binding IsSmoothMode}">
+                Grid.Row="0">
 
                 <!-- Hardness Slider -->
                 <DockPanel
@@ -34,11 +33,11 @@
                     <elements:MouseWheelSlider
                         Margin="5,0"
                         VerticalAlignment="Center"
-                        ToolTip.Tip="{Binding BlendHardnessValue}"
+                        ToolTip.Tip="{Binding PivotSmooth.BlendHardnessValue}"
                         Maximum="1"
                         Minimum="0"
                         SmallChange="0.01"
-                        Value="{Binding BlendHardnessValue}" />
+                        Value="{Binding PivotSmooth.BlendHardnessValue}" />
                 </DockPanel>
 
                 <!-- Widening Slider -->
@@ -91,11 +90,11 @@
                     <elements:MouseWheelSlider
                         Margin="5,0"
                         VerticalAlignment="Center"
-                        ToolTip.Tip="{Binding WideningValue}"
+                        ToolTip.Tip="{Binding PivotSmooth.WideningValue}"
                         Maximum="1"
                         Minimum="0"
                         SmallChange="0.01"
-                        Value="{Binding WideningValue}" />
+                        Value="{Binding PivotSmooth.WideningValue}" />
                 </DockPanel>
 
                 <!-- Shift Slider -->
@@ -148,11 +147,11 @@
                     <elements:MouseWheelSlider
                         Margin="5,0"
                         VerticalAlignment="Center"
-                        ToolTip.Tip="{Binding ShiftValue}"
+                        ToolTip.Tip="{Binding PivotSmooth.ShiftValue}"
                         Maximum="1"
                         Minimum="-1"
                         SmallChange="0.01"
-                        Value="{Binding ShiftValue}" />
+                        Value="{Binding PivotSmooth.ShiftValue}" />
                 </DockPanel>
             </StackPanel>
 </UserControl>

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowUnderfillingUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowUnderfillingUserControl.axaml
@@ -1,10 +1,10 @@
-<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowUnderfillingUserControl"
+﻿<UserControl x:Class="TgaBuilderAvaloniaUi.View.TransitionWindowUnderfillingUserControl"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:elements="clr-namespace:TgaBuilderAvaloniaUi.Elements"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
              xmlns:ap="clr-namespace:TgaBuilderAvaloniaUi.AttachedProperties"
-             x:DataType="viewmodel:TransitionViewModel"
+             x:DataType="viewmodel:TransitionUnderfillingViewModel"
              x:CompileBindings="False">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -29,7 +29,7 @@
             MinWidth="36"
             Icon="{StaticResource camera_switch}"
             ap:MouseOverInfoAP.InfoText="Turn the underfilling into an overfilling by substituting brigth pixes instead, possible for sandy textures and bright backgrounds"
-            IsChecked="{Binding ReverseUnderfilling}" />
+            IsChecked="{Binding Underfilling.ReverseUnderfilling}" />
     </StackPanel>
 
     <!-- Row 2: Underfilling Threshold Slider & Icons -->
@@ -46,11 +46,11 @@
     <elements:MouseWheelSlider Grid.Row="1" Grid.Column="1"
                                Margin="5,0,5,8"
                                VerticalAlignment="Center"
-                               ToolTip.Tip="{Binding UnderfillingThreshold}"
+                               ToolTip.Tip="{Binding Underfilling.UnderfillingThreshold}"
                                Maximum="255"
                                Minimum="0"
                                SmallChange="1"
-                               Value="{Binding UnderfillingThreshold}"
+                               Value="{Binding Underfilling.UnderfillingThreshold}"
                                ap:MouseOverInfoAP.InfoText="Underfilling Threshold: 0 = no underfilling, 255 = maximum underfilling" />
     
     <Path Grid.Row="1" Grid.Column="2"
@@ -111,11 +111,11 @@
             <elements:MouseWheelSlider Grid.Row="2" Grid.Column="1"
                 Margin="5,0"
                 VerticalAlignment="Center"
-                ToolTip.Tip="{Binding UnderfillingPivot}"
+                ToolTip.Tip="{Binding Underfilling.UnderfillingPivot}"
                 Maximum="1"
                 Minimum="0"
                 SmallChange="0.01"
                 ap:MouseOverInfoAP.InfoText="Underfilling pivot: sets the position of the underfilling area (0 = left, 1 = right)"
-                Value="{Binding UnderfillingPivot}" />
+                Value="{Binding Underfilling.UnderfillingPivot}" />
     </Grid>
 </UserControl>

--- a/TgaBuilderLib/Modifications/IModificationsHelper.cs
+++ b/TgaBuilderLib/Modifications/IModificationsHelper.cs
@@ -46,5 +46,10 @@ namespace TgaBuilderLib.Modifications
         // =====================================================================
 
         byte[] Apply(byte[] inputPixels);
+
+        /// <summary>
+        /// Resets all helper state to defaults.
+        /// </summary>
+        void CleanUp();
     }
 }

--- a/TgaBuilderLib/Modifications/ModificationsHelper.cs
+++ b/TgaBuilderLib/Modifications/ModificationsHelper.cs
@@ -519,5 +519,36 @@ namespace TgaBuilderLib.Modifications
 
         private static byte Clamp01(float v)
             => (byte)Math.Clamp((int)(v * 255f + 0.5f), 0, 255);
+
+        // =====================================================================
+        // CleanUp — resets all parameters to defaults
+        // =====================================================================
+
+        public void CleanUp()
+        {
+            Width = 0;
+            Height = 0;
+
+            Exposure = 0f;
+            Brightness = 0f;
+            Contrast = 0f;
+            Highlights = 0f;
+            Shadows = 0f;
+            Whites = 0f;
+            Blacks = 0f;
+
+            Saturation = 0f;
+            Vibrance = 0f;
+            Hue = 0f;
+            Temperature = 0f;
+            Tint = 0f;
+
+            ColorOverlay = new Color(0, 0, 0, 0);
+            ColorOverlayAmount = 0f;
+            ColorOverlayMixMode = ColorOverlayMixMode.Linear;
+            ColorOverlaySoftLightStrength = 1f;
+            ColorOverlayLumaPreservation = 1f;
+            ColorOverlayChromaBoost = 1f;
+        }
     }
 }

--- a/TgaBuilderLib/ViewModel/Modifications/BasicViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/BasicViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class BasicViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Modifications/BasicViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/BasicViewModel.cs
@@ -1,5 +1,5 @@
-﻿using TgaBuilderLib.Modifications;
-using TgaBuilderLib.ViewModel.Modifications;
+using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Modifications;
 
 namespace TgaBuilderLib.ViewModel.Modifications;
 
@@ -10,19 +10,18 @@ namespace TgaBuilderLib.ViewModel.Modifications;
 public class ModificationsBasicViewModel : ThrottledViewModelBase
 {
     public ModificationsBasicViewModel(
+        IMediaFactory mediaFactory,
         IModificationsHelper modificationsHelper,
         ModificationsPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _modificationsHelper = modificationsHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly IModificationsHelper _modificationsHelper;
     public ModificationsPresentersViewModel Presenters { get; }
-
-    // =====================================================================
-    // Fields
-    // =====================================================================
 
     private float _exposure;
     private float _brightness;
@@ -31,10 +30,6 @@ public class ModificationsBasicViewModel : ThrottledViewModelBase
     private float _shadows;
     private float _whites;
     private float _blacks;
-
-    // =====================================================================
-    // Properties
-    // =====================================================================
 
     public float Exposure
     {
@@ -78,10 +73,6 @@ public class ModificationsBasicViewModel : ThrottledViewModelBase
         set => SetPropertyTriggerRecalculation(ref _blacks, value);
     }
 
-    // =====================================================================
-    // ThrottledViewModelBase overrides
-    // =====================================================================
-
     protected override bool DoPreProcessing()
     {
         _modificationsHelper.Exposure = _exposure;
@@ -96,6 +87,22 @@ public class ModificationsBasicViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent ModificationsViewModel
+        var pixels = Presenters.InputPixels;
+        if (pixels == null || pixels.Length == 0) return;
+
+        int w = Presenters.InputImage.PixelWidth;
+        int h = Presenters.InputImage.PixelHeight;
+        if (w == 0 || h == 0) return;
+
+        _modificationsHelper.Width = w;
+        _modificationsHelper.Height = h;
+
+        byte[] inputCopy = new byte[pixels.Length];
+        System.Array.Copy(pixels, inputCopy, pixels.Length);
+
+        byte[] result = _modificationsHelper.Apply(inputCopy);
+
+        var resultBmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(resultBmp);
     }
 }

--- a/TgaBuilderLib/ViewModel/Modifications/BasicViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/BasicViewModel.cs
@@ -1,11 +1,101 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Modifications;
+using TgaBuilderLib.ViewModel.Modifications;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Modifications;
 
-internal class BasicViewModel
+/// <summary>
+/// Child VM for the Modifications basic adjustments section.
+/// Controls exposure, brightness, contrast, highlights, shadows, whites, blacks.
+/// </summary>
+public class ModificationsBasicViewModel : ThrottledViewModelBase
 {
+    public ModificationsBasicViewModel(
+        IModificationsHelper modificationsHelper,
+        ModificationsPresentersViewModel presenters)
+    {
+        _modificationsHelper = modificationsHelper;
+        Presenters = presenters;
+    }
+
+    private readonly IModificationsHelper _modificationsHelper;
+    public ModificationsPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private float _exposure;
+    private float _brightness;
+    private float _contrast;
+    private float _highlights;
+    private float _shadows;
+    private float _whites;
+    private float _blacks;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public float Exposure
+    {
+        get => _exposure;
+        set => SetPropertyTriggerRecalculation(ref _exposure, value);
+    }
+
+    public float Brightness
+    {
+        get => _brightness;
+        set => SetPropertyTriggerRecalculation(ref _brightness, value);
+    }
+
+    public float Contrast
+    {
+        get => _contrast;
+        set => SetPropertyTriggerRecalculation(ref _contrast, value);
+    }
+
+    public float Highlights
+    {
+        get => _highlights;
+        set => SetPropertyTriggerRecalculation(ref _highlights, value);
+    }
+
+    public float Shadows
+    {
+        get => _shadows;
+        set => SetPropertyTriggerRecalculation(ref _shadows, value);
+    }
+
+    public float Whites
+    {
+        get => _whites;
+        set => SetPropertyTriggerRecalculation(ref _whites, value);
+    }
+
+    public float Blacks
+    {
+        get => _blacks;
+        set => SetPropertyTriggerRecalculation(ref _blacks, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _modificationsHelper.Exposure = _exposure;
+        _modificationsHelper.Brightness = _brightness;
+        _modificationsHelper.Contrast = _contrast;
+        _modificationsHelper.Highlights = _highlights;
+        _modificationsHelper.Shadows = _shadows;
+        _modificationsHelper.Whites = _whites;
+        _modificationsHelper.Blacks = _blacks;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent ModificationsViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Modifications/ColorOverlayViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/ColorOverlayViewModel.cs
@@ -1,11 +1,138 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Enums;
+using TgaBuilderLib.Modifications;
+using TgaBuilderLib.ViewModel.Modifications;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Modifications;
 
-internal class ColorOverlayViewModel
+/// <summary>
+/// Child VM for the Modifications color overlay section.
+/// Controls overlay color, amount, mix mode, and mode-specific parameters.
+/// </summary>
+public class ModificationsColorOverlayViewModel : ThrottledViewModelBase
 {
+    public ModificationsColorOverlayViewModel(
+        IModificationsHelper modificationsHelper,
+        ModificationsPresentersViewModel presenters)
+    {
+        _modificationsHelper = modificationsHelper;
+        Presenters = presenters;
+    }
+
+    private readonly IModificationsHelper _modificationsHelper;
+    public ModificationsPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private Color _colorOverlay = new(0, 0, 0, 0);
+    private float _colorOverlayAmount;
+    private int _selectedColorOverlayMixModeIndex = (int)ColorOverlayMixMode.OklabChroma;
+    private float _colorOverlaySoftLightStrength = 1f;
+    private float _colorOverlayLumaPreservation = 1f;
+    private float _colorOverlayChromaBoost = 1f;
+    private bool _isColorOverlayEyedropperMode;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public Color ColorOverlay
+    {
+        get => _colorOverlay;
+        set => SetPropertyTriggerRecalculation(ref _colorOverlay, value);
+    }
+
+    public float ColorOverlayAmount
+    {
+        get => _colorOverlayAmount;
+        set
+        {
+            float clamped = Math.Clamp(value, 0f, 1f);
+            if (Math.Abs(_colorOverlayAmount - clamped) > float.Epsilon)
+            {
+                _colorOverlayAmount = clamped;
+                OnPropertyChanged(nameof(ColorOverlayAmount));
+                OnPropertyChanged(nameof(ColorOverlayBlendPercent));
+                _ = TriggerRecalculation();
+            }
+        }
+    }
+
+    public float ColorOverlayBlendPercent
+    {
+        get => _colorOverlayAmount * 100f;
+        set => ColorOverlayAmount = Math.Clamp(value, 0f, 100f) / 100f;
+    }
+
+    public int SelectedColorOverlayMixModeIndex
+    {
+        get => _selectedColorOverlayMixModeIndex;
+        set
+        {
+            if (_selectedColorOverlayMixModeIndex != value)
+            {
+                _selectedColorOverlayMixModeIndex = value;
+                OnPropertyChanged(nameof(SelectedColorOverlayMixModeIndex));
+                OnPropertyChanged(nameof(IsColorOverlaySoftLightMode));
+                OnPropertyChanged(nameof(IsColorOverlayOklabMode));
+                _ = TriggerRecalculation();
+            }
+        }
+    }
+
+    public float ColorOverlaySoftLightStrength
+    {
+        get => _colorOverlaySoftLightStrength;
+        set => SetPropertyTriggerRecalculation(ref _colorOverlaySoftLightStrength, value);
+    }
+
+    public float ColorOverlayLumaPreservation
+    {
+        get => _colorOverlayLumaPreservation;
+        set => SetPropertyTriggerRecalculation(ref _colorOverlayLumaPreservation, value);
+    }
+
+    public float ColorOverlayChromaBoost
+    {
+        get => _colorOverlayChromaBoost;
+        set => SetPropertyTriggerRecalculation(ref _colorOverlayChromaBoost, value);
+    }
+
+    public bool IsColorOverlaySoftLightMode
+        => SelectedColorOverlayMixModeIndex == (int)ColorOverlayMixMode.SoftLight;
+
+    public bool IsColorOverlayOklabMode
+        => SelectedColorOverlayMixModeIndex == (int)ColorOverlayMixMode.OklabChroma;
+
+    public bool IsColorOverlayEyedropperMode
+    {
+        get => _isColorOverlayEyedropperMode;
+        set => SetCallerProperty(ref _isColorOverlayEyedropperMode, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _modificationsHelper.ColorOverlay = _colorOverlay;
+        _modificationsHelper.ColorOverlayAmount = _colorOverlayAmount;
+        _modificationsHelper.ColorOverlayMixMode = (ColorOverlayMixMode)Math.Clamp(
+            _selectedColorOverlayMixModeIndex,
+            (int)ColorOverlayMixMode.Linear,
+            (int)ColorOverlayMixMode.OklabChroma);
+        _modificationsHelper.ColorOverlaySoftLightStrength = _colorOverlaySoftLightStrength;
+        _modificationsHelper.ColorOverlayLumaPreservation = _colorOverlayLumaPreservation;
+        _modificationsHelper.ColorOverlayChromaBoost = _colorOverlayChromaBoost;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent ModificationsViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Modifications/ColorOverlayViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/ColorOverlayViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class ColorOverlayViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Modifications/ColorOverlayViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/ColorOverlayViewModel.cs
@@ -1,8 +1,7 @@
-﻿using System;
+using System;
 using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.Enums;
 using TgaBuilderLib.Modifications;
-using TgaBuilderLib.ViewModel.Modifications;
 
 namespace TgaBuilderLib.ViewModel.Modifications;
 
@@ -13,19 +12,18 @@ namespace TgaBuilderLib.ViewModel.Modifications;
 public class ModificationsColorOverlayViewModel : ThrottledViewModelBase
 {
     public ModificationsColorOverlayViewModel(
+        IMediaFactory mediaFactory,
         IModificationsHelper modificationsHelper,
         ModificationsPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _modificationsHelper = modificationsHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly IModificationsHelper _modificationsHelper;
     public ModificationsPresentersViewModel Presenters { get; }
-
-    // =====================================================================
-    // Fields
-    // =====================================================================
 
     private Color _colorOverlay = new(0, 0, 0, 0);
     private float _colorOverlayAmount;
@@ -34,10 +32,6 @@ public class ModificationsColorOverlayViewModel : ThrottledViewModelBase
     private float _colorOverlayLumaPreservation = 1f;
     private float _colorOverlayChromaBoost = 1f;
     private bool _isColorOverlayEyedropperMode;
-
-    // =====================================================================
-    // Properties
-    // =====================================================================
 
     public Color ColorOverlay
     {
@@ -113,10 +107,6 @@ public class ModificationsColorOverlayViewModel : ThrottledViewModelBase
         set => SetCallerProperty(ref _isColorOverlayEyedropperMode, value);
     }
 
-    // =====================================================================
-    // ThrottledViewModelBase overrides
-    // =====================================================================
-
     protected override bool DoPreProcessing()
     {
         _modificationsHelper.ColorOverlay = _colorOverlay;
@@ -133,6 +123,22 @@ public class ModificationsColorOverlayViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent ModificationsViewModel
+        var pixels = Presenters.InputPixels;
+        if (pixels == null || pixels.Length == 0) return;
+
+        int w = Presenters.InputImage.PixelWidth;
+        int h = Presenters.InputImage.PixelHeight;
+        if (w == 0 || h == 0) return;
+
+        _modificationsHelper.Width = w;
+        _modificationsHelper.Height = h;
+
+        byte[] inputCopy = new byte[pixels.Length];
+        System.Array.Copy(pixels, inputCopy, pixels.Length);
+
+        byte[] result = _modificationsHelper.Apply(inputCopy);
+
+        var resultBmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(resultBmp);
     }
 }

--- a/TgaBuilderLib/ViewModel/Modifications/ColorViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/ColorViewModel.cs
@@ -1,11 +1,85 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Modifications;
+using TgaBuilderLib.ViewModel.Modifications;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Modifications;
 
-internal class ColorViewModel
+/// <summary>
+/// Child VM for the Modifications color adjustments section.
+/// Controls saturation, vibrance, hue, temperature, tint.
+/// </summary>
+public class ModificationsColorViewModel : ThrottledViewModelBase
 {
+    public ModificationsColorViewModel(
+        IModificationsHelper modificationsHelper,
+        ModificationsPresentersViewModel presenters)
+    {
+        _modificationsHelper = modificationsHelper;
+        Presenters = presenters;
+    }
+
+    private readonly IModificationsHelper _modificationsHelper;
+    public ModificationsPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private float _saturation;
+    private float _vibrance;
+    private float _hue;
+    private float _temperature;
+    private float _tint;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public float Saturation
+    {
+        get => _saturation;
+        set => SetPropertyTriggerRecalculation(ref _saturation, value);
+    }
+
+    public float Vibrance
+    {
+        get => _vibrance;
+        set => SetPropertyTriggerRecalculation(ref _vibrance, value);
+    }
+
+    public float Hue
+    {
+        get => _hue;
+        set => SetPropertyTriggerRecalculation(ref _hue, value);
+    }
+
+    public float Temperature
+    {
+        get => _temperature;
+        set => SetPropertyTriggerRecalculation(ref _temperature, value);
+    }
+
+    public float Tint
+    {
+        get => _tint;
+        set => SetPropertyTriggerRecalculation(ref _tint, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _modificationsHelper.Saturation = _saturation;
+        _modificationsHelper.Vibrance = _vibrance;
+        _modificationsHelper.Hue = _hue;
+        _modificationsHelper.Temperature = _temperature;
+        _modificationsHelper.Tint = _tint;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent ModificationsViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Modifications/ColorViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/ColorViewModel.cs
@@ -1,5 +1,5 @@
-﻿using TgaBuilderLib.Modifications;
-using TgaBuilderLib.ViewModel.Modifications;
+using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Modifications;
 
 namespace TgaBuilderLib.ViewModel.Modifications;
 
@@ -10,29 +10,24 @@ namespace TgaBuilderLib.ViewModel.Modifications;
 public class ModificationsColorViewModel : ThrottledViewModelBase
 {
     public ModificationsColorViewModel(
+        IMediaFactory mediaFactory,
         IModificationsHelper modificationsHelper,
         ModificationsPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _modificationsHelper = modificationsHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly IModificationsHelper _modificationsHelper;
     public ModificationsPresentersViewModel Presenters { get; }
-
-    // =====================================================================
-    // Fields
-    // =====================================================================
 
     private float _saturation;
     private float _vibrance;
     private float _hue;
     private float _temperature;
     private float _tint;
-
-    // =====================================================================
-    // Properties
-    // =====================================================================
 
     public float Saturation
     {
@@ -64,10 +59,6 @@ public class ModificationsColorViewModel : ThrottledViewModelBase
         set => SetPropertyTriggerRecalculation(ref _tint, value);
     }
 
-    // =====================================================================
-    // ThrottledViewModelBase overrides
-    // =====================================================================
-
     protected override bool DoPreProcessing()
     {
         _modificationsHelper.Saturation = _saturation;
@@ -80,6 +71,22 @@ public class ModificationsColorViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent ModificationsViewModel
+        var pixels = Presenters.InputPixels;
+        if (pixels == null || pixels.Length == 0) return;
+
+        int w = Presenters.InputImage.PixelWidth;
+        int h = Presenters.InputImage.PixelHeight;
+        if (w == 0 || h == 0) return;
+
+        _modificationsHelper.Width = w;
+        _modificationsHelper.Height = h;
+
+        byte[] inputCopy = new byte[pixels.Length];
+        System.Array.Copy(pixels, inputCopy, pixels.Length);
+
+        byte[] result = _modificationsHelper.Apply(inputCopy);
+
+        var resultBmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(resultBmp);
     }
 }

--- a/TgaBuilderLib/ViewModel/Modifications/ColorViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/ColorViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class ColorViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Modifications/PresentersViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/PresentersViewModel.cs
@@ -1,11 +1,49 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Abstraction;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Modifications;
 
-internal class PresentersViewModel
+/// <summary>
+/// Holds shared bitmap/image state for all modification child view models.
+/// The window VM and each child hold a reference to this instance.
+/// </summary>
+public class ModificationsPresentersViewModel : ViewModelBase
 {
+    public ModificationsPresentersViewModel(IMediaFactory mediaFactory)
+    {
+        _mediaFactory = mediaFactory;
+        _inputImage = _mediaFactory.CreateEmptyBitmap(42, 42, true);
+        _resultImage = _mediaFactory.CreateEmptyBitmap(42, 42, true);
+        _inputPixels = new byte[42];
+    }
+
+    private readonly IMediaFactory _mediaFactory;
+
+    private IWriteableBitmap _inputImage;
+    private IWriteableBitmap _resultImage;
+    private byte[] _inputPixels;
+    private bool _initTextVisible = true;
+
+    public IWriteableBitmap InputImage
+    {
+        get => _inputImage;
+        set => SetCallerProperty(ref _inputImage, value);
+    }
+
+    public IWriteableBitmap ResultImage
+    {
+        get => _resultImage;
+        set => SetCallerProperty(ref _resultImage, value);
+    }
+
+    public bool InitTextVisible
+    {
+        get => _initTextVisible;
+        set => SetCallerProperty(ref _initTextVisible, value);
+    }
+
+    public byte[] InputPixels
+    {
+        get => _inputPixels;
+        set => _inputPixels = value;
+    }
 }

--- a/TgaBuilderLib/ViewModel/Modifications/PresentersViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/PresentersViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class PresentersViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/ThrottledViewModelBase.cs
+++ b/TgaBuilderLib/ViewModel/ThrottledViewModelBase.cs
@@ -1,15 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace TgaBuilderLib.ViewModel;
 
 public abstract class ThrottledViewModelBase : ViewModelBase
 {
-
     private const int RECALC_DELAY_MS = 50;
 
     private readonly object _recalcLock = new();
@@ -19,6 +16,8 @@ public abstract class ThrottledViewModelBase : ViewModelBase
     protected abstract bool DoPreProcessing();
 
     protected abstract void Recalculate();
+
+    public void RequestRecalculation() => _ = TriggerRecalculation();
 
     protected async Task TriggerRecalculation()
     {

--- a/TgaBuilderLib/ViewModel/ThrottledViewModelBase.cs
+++ b/TgaBuilderLib/ViewModel/ThrottledViewModelBase.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal abstract class ThrottledViewModelBase : ViewModelBase
+{
+
+    private const int RECALC_DELAY_MS = 50;
+
+    private readonly object _recalcLock = new();
+    private bool _recalcUpdateRunning;
+    private bool _recalcUpdatePending;
+
+    protected abstract bool DoPreProcessing();
+
+    protected abstract void Recalculate();
+
+    protected async Task TriggerRecalculation()
+    {
+        lock (_recalcLock)
+        {
+            if (_recalcUpdateRunning)
+            {
+                _recalcUpdatePending = true;
+                return;
+            }
+
+            _recalcUpdateRunning = true;
+        }
+
+        try
+        {
+            do
+            {
+                lock (_recalcLock)
+                {
+                    _recalcUpdatePending = false;
+                }
+
+                if (!DoPreProcessing())
+                    return;
+
+                await Task.Delay(RECALC_DELAY_MS);
+
+                Recalculate();
+            }
+            while (_recalcUpdatePending);
+        }
+        finally
+        {
+            lock (_recalcLock)
+            {
+                _recalcUpdateRunning = false;
+            }
+        }
+    }
+
+    private void SetPropertyTriggerRecalculation<T>(
+        ref T field,
+        T value,
+        [CallerMemberName] string? propertyName = null)
+    {
+        if (!EqualityComparer<T>.Default.Equals(field, value))
+        {
+            field = value;
+            OnPropertyChanged(propertyName ?? string.Empty);
+            _ = TriggerRecalculation();
+        }
+    }
+
+    private bool SetCallerPropertyReturn<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (!EqualityComparer<T>.Default.Equals(field, value))
+        {
+            field = value;
+            OnPropertyChanged(propertyName ?? string.Empty);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/TgaBuilderLib/ViewModel/ThrottledViewModelBase.cs
+++ b/TgaBuilderLib/ViewModel/ThrottledViewModelBase.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace TgaBuilderLib.ViewModel;
 
-internal abstract class ThrottledViewModelBase : ViewModelBase
+public abstract class ThrottledViewModelBase : ViewModelBase
 {
 
     private const int RECALC_DELAY_MS = 50;
@@ -60,7 +60,7 @@ internal abstract class ThrottledViewModelBase : ViewModelBase
         }
     }
 
-    private void SetPropertyTriggerRecalculation<T>(
+    protected void SetPropertyTriggerRecalculation<T>(
         ref T field,
         T value,
         [CallerMemberName] string? propertyName = null)
@@ -73,7 +73,7 @@ internal abstract class ThrottledViewModelBase : ViewModelBase
         }
     }
 
-    private bool SetCallerPropertyReturn<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    protected bool SetCallerPropertyReturn<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
     {
         if (!EqualityComparer<T>.Default.Equals(field, value))
         {

--- a/TgaBuilderLib/ViewModel/Transitions/AnalysisViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/AnalysisViewModel.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.Transitions;
-using TgaBuilderLib.ViewModel.Transitions;
 using static TgaBuilderLib.Transitions.TransitionHelper;
 
 namespace TgaBuilderLib.ViewModel.Transitions;
@@ -13,13 +11,16 @@ namespace TgaBuilderLib.ViewModel.Transitions;
 public class TransitionAnalysisViewModel : ThrottledViewModelBase
 {
     public TransitionAnalysisViewModel(
+        IMediaFactory mediaFactory,
         ITransitionHelper transitionHelper,
         TransitionPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _transitionHelper = transitionHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly ITransitionHelper _transitionHelper;
     public TransitionPresentersViewModel Presenters { get; }
 
@@ -204,6 +205,38 @@ public class TransitionAnalysisViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent TransitionViewModel
+        var p1 = Presenters.Pixels1;
+        var p2 = Presenters.Pixels2;
+        if (p1 == null || p2 == null || p1.Length == 0 || p2.Length == 0)
+            return;
+
+        int w = Presenters.Image1.PixelWidth;
+        int h = Presenters.Image1.PixelHeight;
+        if (w == 0 || h == 0)
+            return;
+
+        if (w != Presenters.Image2.PixelWidth || h != Presenters.Image2.PixelHeight)
+            return;
+
+        _transitionHelper.Width = w;
+        _transitionHelper.Height = h;
+
+        byte[] result = Presenters.IsSmoothMode
+            ? _transitionHelper.MixSmooth(p1, p2)
+            : _transitionHelper.MixBricks(p1, p2);
+
+        var bmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(bmp);
+
+        if (!Presenters.IsSmoothMode)
+        {
+            byte[] mapData = _transitionHelper.GetLabelMap();
+            if (mapData.Length > 0)
+            {
+                var labelBmp = _mediaFactory.CreateEmptyBitmap(w, h, true);
+                labelBmp.WritePixels(new PixelRect(0, 0, w, h), mapData, w * 4);
+                Presenters.LabelMapImage = labelBmp;
+            }
+        }
     }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/AnalysisViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/AnalysisViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class AnalysisViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Transitions/AnalysisViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/AnalysisViewModel.cs
@@ -1,11 +1,209 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using TgaBuilderLib.Transitions;
+using TgaBuilderLib.ViewModel.Transitions;
+using static TgaBuilderLib.Transitions.TransitionHelper;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Transitions;
 
-internal class AnalysisViewModel
+/// <summary>
+/// Child VM for the Brick Analysis expander section.
+/// Controls segmentation method, filter, and analysis parameters.
+/// </summary>
+public class TransitionAnalysisViewModel : ThrottledViewModelBase
 {
+    public TransitionAnalysisViewModel(
+        ITransitionHelper transitionHelper,
+        TransitionPresentersViewModel presenters)
+    {
+        _transitionHelper = transitionHelper;
+        Presenters = presenters;
+    }
+
+    private readonly ITransitionHelper _transitionHelper;
+    public TransitionPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private bool _invertGrayscale;
+    private int _markerCount = 42;
+    private int _markerRadius = 5;
+    private float _gridFitAngle = 0f;
+    private FilterType _selectedFilter = FilterType.Gaussian;
+    private SegmentationMethod _selectedSegmentationMethod = SegmentationMethod.Felzenszwalb;
+    private int _felzenszwalbMinSize = 50;
+    private float _felzenszwalbScale = 100f;
+    private int _slicSegmentCount = 250;
+    private float _slicCompactness = 10f;
+    private int _quickshiftMaxDist = 10;
+    private float _quickshiftRatio = 1f;
+    private float _bilateralSigma = 30f;
+    private float _gaussianSigma = 1f;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public bool InvertGrayscale
+    {
+        get => _invertGrayscale;
+        set => SetPropertyTriggerRecalculation(ref _invertGrayscale, value);
+    }
+
+    public int MarkerCount
+    {
+        get => _markerCount;
+        set => SetPropertyTriggerRecalculation(ref _markerCount, value);
+    }
+
+    public int MarkerRadius
+    {
+        get => _markerRadius;
+        set => SetPropertyTriggerRecalculation(ref _markerRadius, value);
+    }
+
+    public float GridFitAngle
+    {
+        get => _gridFitAngle;
+        set => SetPropertyTriggerRecalculation(ref _gridFitAngle, value);
+    }
+
+    public FilterType SelectedFilter
+    {
+        get => _selectedFilter;
+        set
+        {
+            if (SetCallerPropertyReturn(ref _selectedFilter, value, nameof(SelectedFilter)))
+            {
+                OnPropertyChanged(nameof(ShowBilateralSigma));
+                OnPropertyChanged(nameof(ShowGaussianSigma));
+                OnPropertyChanged(nameof(SelectedFilterIndex));
+                _ = TriggerRecalculation();
+            }
+        }
+    }
+
+    public int SelectedFilterIndex
+    {
+        get => (int)_selectedFilter;
+        set => SelectedFilter = (FilterType)value;
+    }
+
+    public SegmentationMethod SelectedSegmentationMethod
+    {
+        get => _selectedSegmentationMethod;
+        set
+        {
+            if (SetCallerPropertyReturn(ref _selectedSegmentationMethod, value, nameof(SelectedSegmentationMethod)))
+            {
+                OnPropertyChanged(nameof(ShowFelzenszwalbParameters));
+                OnPropertyChanged(nameof(ShowSlicParameters));
+                OnPropertyChanged(nameof(ShowQuickshiftParameters));
+                OnPropertyChanged(nameof(ShowWatershedBasedSegmentationInputs));
+                OnPropertyChanged(nameof(ShowGridFittingSegmentationInputs));
+                OnPropertyChanged(nameof(SelectedSegmentationMethodIndex));
+                OnPropertyChanged(nameof(ShowGrayBasedSegmentationInputs));
+                _ = TriggerRecalculation();
+            }
+        }
+    }
+
+    public int SelectedSegmentationMethodIndex
+    {
+        get => (int)_selectedSegmentationMethod;
+        set => SelectedSegmentationMethod = (SegmentationMethod)value;
+    }
+
+    public bool ShowFelzenszwalbParameters => SelectedSegmentationMethod == SegmentationMethod.Felzenszwalb;
+    public bool ShowSlicParameters => SelectedSegmentationMethod == SegmentationMethod.Slic;
+    public bool ShowQuickshiftParameters => SelectedSegmentationMethod == SegmentationMethod.Quickshift;
+    public bool ShowBilateralSigma => SelectedFilter == FilterType.Bilateral;
+    public bool ShowGaussianSigma => SelectedFilter == FilterType.Gaussian;
+    public bool ShowWatershedBasedSegmentationInputs => SelectedSegmentationMethod == SegmentationMethod.Watershed;
+
+    public bool ShowGridFittingSegmentationInputs =>
+        SelectedSegmentationMethod == SegmentationMethod.BrickFit ||
+        SelectedSegmentationMethod == SegmentationMethod.GridFit;
+
+    public bool ShowGrayBasedSegmentationInputs =>
+        ShowWatershedBasedSegmentationInputs || ShowGridFittingSegmentationInputs;
+
+    public int FelzenszwalbMinSize
+    {
+        get => _felzenszwalbMinSize;
+        set => SetPropertyTriggerRecalculation(ref _felzenszwalbMinSize, value);
+    }
+
+    public float FelzenszwalbScale
+    {
+        get => _felzenszwalbScale;
+        set => SetPropertyTriggerRecalculation(ref _felzenszwalbScale, value);
+    }
+
+    public int SlicSegmentCount
+    {
+        get => _slicSegmentCount;
+        set => SetPropertyTriggerRecalculation(ref _slicSegmentCount, value);
+    }
+
+    public float SlicCompactness
+    {
+        get => _slicCompactness;
+        set => SetPropertyTriggerRecalculation(ref _slicCompactness, value);
+    }
+
+    public int QuickshiftMaxDist
+    {
+        get => _quickshiftMaxDist;
+        set => SetPropertyTriggerRecalculation(ref _quickshiftMaxDist, value);
+    }
+
+    public float QuickshiftRatio
+    {
+        get => _quickshiftRatio;
+        set => SetPropertyTriggerRecalculation(ref _quickshiftRatio, value);
+    }
+
+    public float BilateralSigma
+    {
+        get => _bilateralSigma;
+        set => SetPropertyTriggerRecalculation(ref _bilateralSigma, value);
+    }
+
+    public float GaussianSigma
+    {
+        get => _gaussianSigma;
+        set => SetPropertyTriggerRecalculation(ref _gaussianSigma, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresAnalysis;
+        _transitionHelper.InvertGrayscale = _invertGrayscale;
+        _transitionHelper.MarkerCount = _markerCount;
+        _transitionHelper.MarkerRadius = _markerRadius;
+        _transitionHelper.GridFitAngle = _gridFitAngle;
+        _transitionHelper.SelectedFilter = _selectedFilter;
+        _transitionHelper.SegmentationMethod = _selectedSegmentationMethod;
+        _transitionHelper.FelzenszwalbMinSize = _felzenszwalbMinSize;
+        _transitionHelper.FelzenszwalbScale = _felzenszwalbScale;
+        _transitionHelper.SlicSegmentCount = _slicSegmentCount;
+        _transitionHelper.SlicCompactness = _slicCompactness;
+        _transitionHelper.QuickshiftMaxDist = _quickshiftMaxDist;
+        _transitionHelper.QuickshiftRatio = _quickshiftRatio;
+        _transitionHelper.BilateralSigma = _bilateralSigma;
+        _transitionHelper.GaussianSigma = _gaussianSigma;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent TransitionViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/EdgeViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/EdgeViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class EdgeViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Transitions/EdgeViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/EdgeViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.Transitions;
-using TgaBuilderLib.ViewModel.Transitions;
 using static TgaBuilderLib.Transitions.TransitionHelper;
 
 namespace TgaBuilderLib.ViewModel.Transitions;
@@ -12,13 +11,16 @@ namespace TgaBuilderLib.ViewModel.Transitions;
 public class TransitionEdgeViewModel : ThrottledViewModelBase
 {
     public TransitionEdgeViewModel(
+        IMediaFactory mediaFactory,
         ITransitionHelper transitionHelper,
         TransitionPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _transitionHelper = transitionHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly ITransitionHelper _transitionHelper;
     public TransitionPresentersViewModel Presenters { get; }
 
@@ -76,6 +78,38 @@ public class TransitionEdgeViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent TransitionViewModel
+        var p1 = Presenters.Pixels1;
+        var p2 = Presenters.Pixels2;
+        if (p1 == null || p2 == null || p1.Length == 0 || p2.Length == 0)
+            return;
+
+        int w = Presenters.Image1.PixelWidth;
+        int h = Presenters.Image1.PixelHeight;
+        if (w == 0 || h == 0)
+            return;
+
+        if (w != Presenters.Image2.PixelWidth || h != Presenters.Image2.PixelHeight)
+            return;
+
+        _transitionHelper.Width = w;
+        _transitionHelper.Height = h;
+
+        byte[] result = Presenters.IsSmoothMode
+            ? _transitionHelper.MixSmooth(p1, p2)
+            : _transitionHelper.MixBricks(p1, p2);
+
+        var bmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(bmp);
+
+        if (!Presenters.IsSmoothMode)
+        {
+            byte[] mapData = _transitionHelper.GetLabelMap();
+            if (mapData.Length > 0)
+            {
+                var labelBmp = _mediaFactory.CreateEmptyBitmap(w, h, true);
+                labelBmp.WritePixels(new PixelRect(0, 0, w, h), mapData, w * 4);
+                Presenters.LabelMapImage = labelBmp;
+            }
+        }
     }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/EdgeViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/EdgeViewModel.cs
@@ -1,11 +1,81 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Transitions;
+using TgaBuilderLib.ViewModel.Transitions;
+using static TgaBuilderLib.Transitions.TransitionHelper;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Transitions;
 
-internal class EdgeViewModel
+/// <summary>
+/// Child VM for the Brick transition edge coloring section.
+/// Controls edge color, blend mode, edge width, and eyedropper mode.
+/// </summary>
+public class TransitionEdgeViewModel : ThrottledViewModelBase
 {
+    public TransitionEdgeViewModel(
+        ITransitionHelper transitionHelper,
+        TransitionPresentersViewModel presenters)
+    {
+        _transitionHelper = transitionHelper;
+        Presenters = presenters;
+    }
+
+    private readonly ITransitionHelper _transitionHelper;
+    public TransitionPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private Color _edgeColor = new Color(255, 255, 255, 128);
+    private EdgeBlendMode _blendMode = EdgeBlendMode.Multiply;
+    private int _edgeWidth = 1;
+    private bool _isEyedropperMode;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public Color EdgeColor
+    {
+        get => _edgeColor;
+        set => SetPropertyTriggerRecalculation(ref _edgeColor, value);
+    }
+
+    public EdgeBlendMode BlendMode
+    {
+        get => _blendMode;
+        set => SetPropertyTriggerRecalculation(ref _blendMode, value);
+    }
+
+    public System.Array EdgeBlendModes => System.Enum.GetValues(typeof(EdgeBlendMode));
+
+    public int EdgeWidth
+    {
+        get => _edgeWidth;
+        set => SetPropertyTriggerRecalculation(ref _edgeWidth, value);
+    }
+
+    public bool IsEyedropperMode
+    {
+        get => _isEyedropperMode;
+        set => SetCallerProperty(ref _isEyedropperMode, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresDrawing;
+        _transitionHelper.EdgeColor = _edgeColor;
+        _transitionHelper.BlendMode = _blendMode;
+        _transitionHelper.EdgeWidth = _edgeWidth;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent TransitionViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/ManualViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/ManualViewModel.cs
@@ -1,11 +1,84 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Transitions;
+using TgaBuilderLib.ViewModel.Transitions;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Transitions;
 
-internal class ManualViewModel
+/// <summary>
+/// Child VM for the Brick transition manual draw/erase section.
+/// Controls explicit tile visibility draw/erase modes.
+/// </summary>
+public class TransitionManualViewModel : ThrottledViewModelBase
 {
+    public TransitionManualViewModel(
+        ITransitionHelper transitionHelper,
+        TransitionPresentersViewModel presenters)
+    {
+        _transitionHelper = transitionHelper;
+        Presenters = presenters;
+    }
+
+    private readonly ITransitionHelper _transitionHelper;
+    public TransitionPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private bool _isExplicitTileVisibilityDrawMode;
+    private bool _isExplicitTileVisibilityEraseMode;
+    private bool _isLabelMapExpanded;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public bool IsExplicitTileVisibilityDrawMode
+    {
+        get => _isExplicitTileVisibilityDrawMode;
+        set
+        {
+            SetProperty(ref _isExplicitTileVisibilityDrawMode, value, nameof(IsExplicitTileVisibilityDrawMode));
+
+            if (!value)
+                return;
+
+            _isExplicitTileVisibilityEraseMode = false;
+            OnPropertyChanged(nameof(IsExplicitTileVisibilityEraseMode));
+        }
+    }
+
+    public bool IsExplicitTileVisibilityEraseMode
+    {
+        get => _isExplicitTileVisibilityEraseMode;
+        set
+        {
+            SetProperty(ref _isExplicitTileVisibilityEraseMode, value, nameof(IsExplicitTileVisibilityEraseMode));
+            if (!value)
+                return;
+
+            _isExplicitTileVisibilityDrawMode = false;
+            OnPropertyChanged(nameof(IsExplicitTileVisibilityDrawMode));
+        }
+    }
+
+    public bool IsLabelMapExpanded
+    {
+        get => _isLabelMapExpanded;
+        set => SetCallerProperty(ref _isLabelMapExpanded, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresSelectionBuilding;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent TransitionViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/ManualViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/ManualViewModel.cs
@@ -1,5 +1,5 @@
-﻿using TgaBuilderLib.Transitions;
-using TgaBuilderLib.ViewModel.Transitions;
+﻿using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Transitions;
 
 namespace TgaBuilderLib.ViewModel.Transitions;
 
@@ -10,13 +10,16 @@ namespace TgaBuilderLib.ViewModel.Transitions;
 public class TransitionManualViewModel : ThrottledViewModelBase
 {
     public TransitionManualViewModel(
+        IMediaFactory mediaFactory,
         ITransitionHelper transitionHelper,
         TransitionPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _transitionHelper = transitionHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly ITransitionHelper _transitionHelper;
     public TransitionPresentersViewModel Presenters { get; }
 
@@ -79,6 +82,38 @@ public class TransitionManualViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent TransitionViewModel
+        var p1 = Presenters.Pixels1;
+        var p2 = Presenters.Pixels2;
+        if (p1 == null || p2 == null || p1.Length == 0 || p2.Length == 0)
+            return;
+
+        int w = Presenters.Image1.PixelWidth;
+        int h = Presenters.Image1.PixelHeight;
+        if (w == 0 || h == 0)
+            return;
+
+        if (w != Presenters.Image2.PixelWidth || h != Presenters.Image2.PixelHeight)
+            return;
+
+        _transitionHelper.Width = w;
+        _transitionHelper.Height = h;
+
+        byte[] result = Presenters.IsSmoothMode
+            ? _transitionHelper.MixSmooth(p1, p2)
+            : _transitionHelper.MixBricks(p1, p2);
+
+        var bmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(bmp);
+
+        if (!Presenters.IsSmoothMode)
+        {
+            byte[] mapData = _transitionHelper.GetLabelMap();
+            if (mapData.Length > 0)
+            {
+                var labelBmp = _mediaFactory.CreateEmptyBitmap(w, h, true);
+                labelBmp.WritePixels(new PixelRect(0, 0, w, h), mapData, w * 4);
+                Presenters.LabelMapImage = labelBmp;
+            }
+        }
     }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/ManualViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/ManualViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class ManualViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Transitions/PivotBricksViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PivotBricksViewModel.cs
@@ -1,11 +1,102 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Transitions;
+using TgaBuilderLib.ViewModel.Transitions;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Transitions;
 
-internal class PivotBricksViewModel
+/// <summary>
+/// Child VM for the Brick transition pivot/selection section.
+/// Controls pivot, widening, shift, reverse, corner slicing, edge protection.
+/// </summary>
+public class TransitionPivotBricksViewModel : ThrottledViewModelBase
 {
+    public TransitionPivotBricksViewModel(
+        ITransitionHelper transitionHelper,
+        TransitionPresentersViewModel presenters)
+    {
+        _transitionHelper = transitionHelper;
+        Presenters = presenters;
+    }
+
+    private readonly ITransitionHelper _transitionHelper;
+    public TransitionPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private TransitionMode _selectedTransitionMode = TransitionMode.Top;
+    private float _pivotValue = 0.5f;
+    private float _wideningValue = 0f;
+    private float _shiftValue = 0f;
+    private bool _reversePivot;
+    private bool _sliceCornerTiles;
+    private bool _protectEdges = true;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public TransitionMode SelectedTransitionMode
+    {
+        get => _selectedTransitionMode;
+        set => SetPropertyTriggerRecalculation(ref _selectedTransitionMode, value);
+    }
+
+    public float PivotValue
+    {
+        get => _pivotValue;
+        set => SetPropertyTriggerRecalculation(ref _pivotValue, value);
+    }
+
+    public float WideningValue
+    {
+        get => _wideningValue;
+        set => SetPropertyTriggerRecalculation(ref _wideningValue, value);
+    }
+
+    public float ShiftValue
+    {
+        get => _shiftValue;
+        set => SetPropertyTriggerRecalculation(ref _shiftValue, value);
+    }
+
+    public bool ReversePivot
+    {
+        get => _reversePivot;
+        set => SetPropertyTriggerRecalculation(ref _reversePivot, value);
+    }
+
+    public bool SliceCornerTiles
+    {
+        get => _sliceCornerTiles;
+        set => SetPropertyTriggerRecalculation(ref _sliceCornerTiles, value);
+    }
+
+    public bool ProtectEdges
+    {
+        get => _protectEdges;
+        set => SetPropertyTriggerRecalculation(ref _protectEdges, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresSelectionBuilding;
+        _transitionHelper.Mode = _selectedTransitionMode;
+        _transitionHelper.Pivot = _pivotValue;
+        _transitionHelper.Widening = _wideningValue;
+        _transitionHelper.Shift = _shiftValue;
+        _transitionHelper.ReversePivot = _reversePivot;
+        _transitionHelper.SliceCornerTiles = _sliceCornerTiles;
+        _transitionHelper.ProtectEdges = _protectEdges;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent TransitionViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/PivotBricksViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PivotBricksViewModel.cs
@@ -1,5 +1,5 @@
-﻿using TgaBuilderLib.Transitions;
-using TgaBuilderLib.ViewModel.Transitions;
+﻿using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Transitions;
 
 namespace TgaBuilderLib.ViewModel.Transitions;
 
@@ -10,13 +10,16 @@ namespace TgaBuilderLib.ViewModel.Transitions;
 public class TransitionPivotBricksViewModel : ThrottledViewModelBase
 {
     public TransitionPivotBricksViewModel(
+        IMediaFactory mediaFactory,
         ITransitionHelper transitionHelper,
         TransitionPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _transitionHelper = transitionHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly ITransitionHelper _transitionHelper;
     public TransitionPresentersViewModel Presenters { get; }
 
@@ -97,6 +100,38 @@ public class TransitionPivotBricksViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent TransitionViewModel
+        var p1 = Presenters.Pixels1;
+        var p2 = Presenters.Pixels2;
+        if (p1 == null || p2 == null || p1.Length == 0 || p2.Length == 0)
+            return;
+
+        int w = Presenters.Image1.PixelWidth;
+        int h = Presenters.Image1.PixelHeight;
+        if (w == 0 || h == 0)
+            return;
+
+        if (w != Presenters.Image2.PixelWidth || h != Presenters.Image2.PixelHeight)
+            return;
+
+        _transitionHelper.Width = w;
+        _transitionHelper.Height = h;
+
+        byte[] result = Presenters.IsSmoothMode
+            ? _transitionHelper.MixSmooth(p1, p2)
+            : _transitionHelper.MixBricks(p1, p2);
+
+        var bmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(bmp);
+
+        if (!Presenters.IsSmoothMode)
+        {
+            byte[] mapData = _transitionHelper.GetLabelMap();
+            if (mapData.Length > 0)
+            {
+                var labelBmp = _mediaFactory.CreateEmptyBitmap(w, h, true);
+                labelBmp.WritePixels(new PixelRect(0, 0, w, h), mapData, w * 4);
+                Presenters.LabelMapImage = labelBmp;
+            }
+        }
     }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/PivotBricksViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PivotBricksViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class PivotBricksViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Transitions/PivotSmoothViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PivotSmoothViewModel.cs
@@ -1,11 +1,85 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Transitions;
+using TgaBuilderLib.ViewModel.Transitions;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Transitions;
 
-internal class PivotSmoothViewModel
+/// <summary>
+/// Child VM for the Smooth transition pivot/blend section.
+/// Controls blend hardness, pivot, widening, shift.
+/// </summary>
+public class TransitionPivotSmoothViewModel : ThrottledViewModelBase
 {
+    public TransitionPivotSmoothViewModel(
+        ITransitionHelper transitionHelper,
+        TransitionPresentersViewModel presenters)
+    {
+        _transitionHelper = transitionHelper;
+        Presenters = presenters;
+    }
+
+    private readonly ITransitionHelper _transitionHelper;
+    public TransitionPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private TransitionMode _selectedTransitionMode = TransitionMode.Top;
+    private float _pivotValue = 0.5f;
+    private float _wideningValue = 0f;
+    private float _shiftValue = 0f;
+    private float _blendHardnessValue = 0.5f;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public TransitionMode SelectedTransitionMode
+    {
+        get => _selectedTransitionMode;
+        set => SetPropertyTriggerRecalculation(ref _selectedTransitionMode, value);
+    }
+
+    public float PivotValue
+    {
+        get => _pivotValue;
+        set => SetPropertyTriggerRecalculation(ref _pivotValue, value);
+    }
+
+    public float WideningValue
+    {
+        get => _wideningValue;
+        set => SetPropertyTriggerRecalculation(ref _wideningValue, value);
+    }
+
+    public float ShiftValue
+    {
+        get => _shiftValue;
+        set => SetPropertyTriggerRecalculation(ref _shiftValue, value);
+    }
+
+    public float BlendHardnessValue
+    {
+        get => _blendHardnessValue;
+        set => SetPropertyTriggerRecalculation(ref _blendHardnessValue, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _transitionHelper.Mode = _selectedTransitionMode;
+        _transitionHelper.Pivot = _pivotValue;
+        _transitionHelper.Widening = _wideningValue;
+        _transitionHelper.Shift = _shiftValue;
+        _transitionHelper.Hardness = _blendHardnessValue;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent TransitionViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/PivotSmoothViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PivotSmoothViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class PivotSmoothViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Transitions/PivotSmoothViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PivotSmoothViewModel.cs
@@ -1,5 +1,5 @@
-﻿using TgaBuilderLib.Transitions;
-using TgaBuilderLib.ViewModel.Transitions;
+﻿using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Transitions;
 
 namespace TgaBuilderLib.ViewModel.Transitions;
 
@@ -10,13 +10,16 @@ namespace TgaBuilderLib.ViewModel.Transitions;
 public class TransitionPivotSmoothViewModel : ThrottledViewModelBase
 {
     public TransitionPivotSmoothViewModel(
+        IMediaFactory mediaFactory,
         ITransitionHelper transitionHelper,
         TransitionPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _transitionHelper = transitionHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly ITransitionHelper _transitionHelper;
     public TransitionPresentersViewModel Presenters { get; }
 
@@ -80,6 +83,38 @@ public class TransitionPivotSmoothViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent TransitionViewModel
+        var p1 = Presenters.Pixels1;
+        var p2 = Presenters.Pixels2;
+        if (p1 == null || p2 == null || p1.Length == 0 || p2.Length == 0)
+            return;
+
+        int w = Presenters.Image1.PixelWidth;
+        int h = Presenters.Image1.PixelHeight;
+        if (w == 0 || h == 0)
+            return;
+
+        if (w != Presenters.Image2.PixelWidth || h != Presenters.Image2.PixelHeight)
+            return;
+
+        _transitionHelper.Width = w;
+        _transitionHelper.Height = h;
+
+        byte[] result = Presenters.IsSmoothMode
+            ? _transitionHelper.MixSmooth(p1, p2)
+            : _transitionHelper.MixBricks(p1, p2);
+
+        var bmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(bmp);
+
+        if (!Presenters.IsSmoothMode)
+        {
+            byte[] mapData = _transitionHelper.GetLabelMap();
+            if (mapData.Length > 0)
+            {
+                var labelBmp = _mediaFactory.CreateEmptyBitmap(w, h, true);
+                labelBmp.WritePixels(new PixelRect(0, 0, w, h), mapData, w * 4);
+                Presenters.LabelMapImage = labelBmp;
+            }
+        }
     }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/PresentersViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PresentersViewModel.cs
@@ -29,6 +29,7 @@ public class TransitionPresentersViewModel : ViewModelBase
     private byte[] _pixels2;
     private bool _initTextVisible = true;
     private bool _isIndicatorMapVisible;
+    private bool _isSmoothMode;
 
     public IWriteableBitmap Image1
     {
@@ -70,6 +71,12 @@ public class TransitionPresentersViewModel : ViewModelBase
     {
         get => _initTextVisible;
         set => SetCallerProperty(ref _initTextVisible, value);
+    }
+
+    public bool IsSmoothMode
+    {
+        get => _isSmoothMode;
+        set => SetCallerProperty(ref _isSmoothMode, value);
     }
 
     public byte[] Pixels1

--- a/TgaBuilderLib/ViewModel/Transitions/PresentersViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PresentersViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class PresentersViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Transitions/PresentersViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/PresentersViewModel.cs
@@ -1,11 +1,88 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Abstraction;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Transitions;
 
-internal class PresentersViewModel
+/// <summary>
+/// Holds shared bitmap/image state for all transition child view models.
+/// The window VM and each child hold a reference to this instance.
+/// </summary>
+public class TransitionPresentersViewModel : ViewModelBase
 {
+    public TransitionPresentersViewModel(IMediaFactory mediaFactory)
+    {
+        _mediaFactory = mediaFactory;
+        _image1 = _mediaFactory.CreateEmptyBitmap(64, 64, true);
+        _image2 = _mediaFactory.CreateEmptyBitmap(64, 64, true);
+        _resultImage = _mediaFactory.CreateEmptyBitmap(64, 64, true);
+        _pixels1 = new byte[64 * 64 * 4];
+        _pixels2 = new byte[64 * 64 * 4];
+    }
+
+    private readonly IMediaFactory _mediaFactory;
+
+    private IWriteableBitmap _image1;
+    private IWriteableBitmap _image2;
+    private IWriteableBitmap _resultImage;
+    private IWriteableBitmap? _labelMapImage;
+    private IWriteableBitmap? _indicatorMapImage;
+    private byte[] _pixels1;
+    private byte[] _pixels2;
+    private bool _initTextVisible = true;
+    private bool _isIndicatorMapVisible;
+
+    public IWriteableBitmap Image1
+    {
+        get => _image1;
+        set => SetCallerProperty(ref _image1, value);
+    }
+
+    public IWriteableBitmap Image2
+    {
+        get => _image2;
+        set => SetCallerProperty(ref _image2, value);
+    }
+
+    public IWriteableBitmap ResultImage
+    {
+        get => _resultImage;
+        set => SetCallerProperty(ref _resultImage, value);
+    }
+
+    public IWriteableBitmap? LabelMapImage
+    {
+        get => _labelMapImage;
+        set => SetCallerProperty(ref _labelMapImage, value);
+    }
+
+    public IWriteableBitmap? IndicatorMapImage
+    {
+        get => _indicatorMapImage;
+        set => SetCallerProperty(ref _indicatorMapImage, value);
+    }
+
+    public bool IsIndicatorMapVisible
+    {
+        get => _isIndicatorMapVisible;
+        set => SetCallerProperty(ref _isIndicatorMapVisible, value);
+    }
+
+    public bool InitTextVisible
+    {
+        get => _initTextVisible;
+        set => SetCallerProperty(ref _initTextVisible, value);
+    }
+
+    public byte[] Pixels1
+    {
+        get => _pixels1;
+        set => _pixels1 = value;
+    }
+
+    public byte[] Pixels2
+    {
+        get => _pixels2;
+        set => _pixels2 = value;
+    }
+
+    public IVisualInvalidator? VisualInvalidator { get; set; }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/ShadowViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/ShadowViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class ShadowViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Transitions/ShadowViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/ShadowViewModel.cs
@@ -1,11 +1,78 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Transitions;
+using TgaBuilderLib.ViewModel.Transitions;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Transitions;
 
-internal class ShadowViewModel
+/// <summary>
+/// Child VM for the Brick transition shadow section.
+/// Controls shadow color, size, hardness, and eyedropper mode.
+/// </summary>
+public class TransitionShadowViewModel : ThrottledViewModelBase
 {
+    public TransitionShadowViewModel(
+        ITransitionHelper transitionHelper,
+        TransitionPresentersViewModel presenters)
+    {
+        _transitionHelper = transitionHelper;
+        Presenters = presenters;
+    }
+
+    private readonly ITransitionHelper _transitionHelper;
+    public TransitionPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private Color _shadowColor = new Color(42, 42, 42, 42);
+    private int _shadowSize = 3;
+    private int _shadowHardness = 50;
+    private bool _isShadowEyedropperMode;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public Color ShadowColor
+    {
+        get => _shadowColor;
+        set => SetPropertyTriggerRecalculation(ref _shadowColor, value);
+    }
+
+    public int ShadowSize
+    {
+        get => _shadowSize;
+        set => SetPropertyTriggerRecalculation(ref _shadowSize, value);
+    }
+
+    public int ShadowHardness
+    {
+        get => _shadowHardness;
+        set => SetPropertyTriggerRecalculation(ref _shadowHardness, value);
+    }
+
+    public bool IsShadowEyedropperMode
+    {
+        get => _isShadowEyedropperMode;
+        set => SetCallerProperty(ref _isShadowEyedropperMode, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresDrawing;
+        _transitionHelper.ShadowColor = _shadowColor;
+        _transitionHelper.ShadowSize = _shadowSize;
+        _transitionHelper.ShadowHardness = _shadowHardness;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent TransitionViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/ShadowViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/ShadowViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.Transitions;
-using TgaBuilderLib.ViewModel.Transitions;
 
 namespace TgaBuilderLib.ViewModel.Transitions;
 
@@ -11,13 +10,16 @@ namespace TgaBuilderLib.ViewModel.Transitions;
 public class TransitionShadowViewModel : ThrottledViewModelBase
 {
     public TransitionShadowViewModel(
+        IMediaFactory mediaFactory,
         ITransitionHelper transitionHelper,
         TransitionPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _transitionHelper = transitionHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly ITransitionHelper _transitionHelper;
     public TransitionPresentersViewModel Presenters { get; }
 
@@ -73,6 +75,38 @@ public class TransitionShadowViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent TransitionViewModel
+        var p1 = Presenters.Pixels1;
+        var p2 = Presenters.Pixels2;
+        if (p1 == null || p2 == null || p1.Length == 0 || p2.Length == 0)
+            return;
+
+        int w = Presenters.Image1.PixelWidth;
+        int h = Presenters.Image1.PixelHeight;
+        if (w == 0 || h == 0)
+            return;
+
+        if (w != Presenters.Image2.PixelWidth || h != Presenters.Image2.PixelHeight)
+            return;
+
+        _transitionHelper.Width = w;
+        _transitionHelper.Height = h;
+
+        byte[] result = Presenters.IsSmoothMode
+            ? _transitionHelper.MixSmooth(p1, p2)
+            : _transitionHelper.MixBricks(p1, p2);
+
+        var bmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(bmp);
+
+        if (!Presenters.IsSmoothMode)
+        {
+            byte[] mapData = _transitionHelper.GetLabelMap();
+            if (mapData.Length > 0)
+            {
+                var labelBmp = _mediaFactory.CreateEmptyBitmap(w, h, true);
+                labelBmp.WritePixels(new PixelRect(0, 0, w, h), mapData, w * 4);
+                Presenters.LabelMapImage = labelBmp;
+            }
+        }
     }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/UnderfillingViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/UnderfillingViewModel.cs
@@ -1,11 +1,70 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using TgaBuilderLib.Transitions;
+using TgaBuilderLib.ViewModel.Transitions;
 
-namespace TgaBuilderLib.ViewModel;
+namespace TgaBuilderLib.ViewModel.Transitions;
 
-internal class UnderfillingViewModel
+/// <summary>
+/// Child VM for the Brick transition underfilling section.
+/// Controls underfilling pivot, reverse, and threshold.
+/// </summary>
+public class TransitionUnderfillingViewModel : ThrottledViewModelBase
 {
+    public TransitionUnderfillingViewModel(
+        ITransitionHelper transitionHelper,
+        TransitionPresentersViewModel presenters)
+    {
+        _transitionHelper = transitionHelper;
+        Presenters = presenters;
+    }
+
+    private readonly ITransitionHelper _transitionHelper;
+    public TransitionPresentersViewModel Presenters { get; }
+
+    // =====================================================================
+    // Fields
+    // =====================================================================
+
+    private float _underfillingPivot = 0.5f;
+    private bool _reverseUnderfilling;
+    private int _underfillingThreshold;
+
+    // =====================================================================
+    // Properties
+    // =====================================================================
+
+    public float UnderfillingPivot
+    {
+        get => _underfillingPivot;
+        set => SetPropertyTriggerRecalculation(ref _underfillingPivot, value);
+    }
+
+    public bool ReverseUnderfilling
+    {
+        get => _reverseUnderfilling;
+        set => SetPropertyTriggerRecalculation(ref _reverseUnderfilling, value);
+    }
+
+    public int UnderfillingThreshold
+    {
+        get => _underfillingThreshold;
+        set => SetPropertyTriggerRecalculation(ref _underfillingThreshold, value);
+    }
+
+    // =====================================================================
+    // ThrottledViewModelBase overrides
+    // =====================================================================
+
+    protected override bool DoPreProcessing()
+    {
+        _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresSelectionBuilding;
+        _transitionHelper.UnderfillingPivot = _underfillingPivot;
+        _transitionHelper.ReverseUnderfilling = _reverseUnderfilling;
+        _transitionHelper.UnderfillingThreshold = _underfillingThreshold;
+        return true;
+    }
+
+    protected override void Recalculate()
+    {
+        // Recalculation is driven by the parent TransitionViewModel
+    }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/UnderfillingViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/UnderfillingViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TgaBuilderLib.ViewModel;
+
+internal class UnderfillingViewModel
+{
+}

--- a/TgaBuilderLib/ViewModel/Transitions/UnderfillingViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/UnderfillingViewModel.cs
@@ -1,5 +1,5 @@
-﻿using TgaBuilderLib.Transitions;
-using TgaBuilderLib.ViewModel.Transitions;
+﻿using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Transitions;
 
 namespace TgaBuilderLib.ViewModel.Transitions;
 
@@ -10,13 +10,16 @@ namespace TgaBuilderLib.ViewModel.Transitions;
 public class TransitionUnderfillingViewModel : ThrottledViewModelBase
 {
     public TransitionUnderfillingViewModel(
+        IMediaFactory mediaFactory,
         ITransitionHelper transitionHelper,
         TransitionPresentersViewModel presenters)
     {
+        _mediaFactory = mediaFactory;
         _transitionHelper = transitionHelper;
         Presenters = presenters;
     }
 
+    private readonly IMediaFactory _mediaFactory;
     private readonly ITransitionHelper _transitionHelper;
     public TransitionPresentersViewModel Presenters { get; }
 
@@ -65,6 +68,38 @@ public class TransitionUnderfillingViewModel : ThrottledViewModelBase
 
     protected override void Recalculate()
     {
-        // Recalculation is driven by the parent TransitionViewModel
+        var p1 = Presenters.Pixels1;
+        var p2 = Presenters.Pixels2;
+        if (p1 == null || p2 == null || p1.Length == 0 || p2.Length == 0)
+            return;
+
+        int w = Presenters.Image1.PixelWidth;
+        int h = Presenters.Image1.PixelHeight;
+        if (w == 0 || h == 0)
+            return;
+
+        if (w != Presenters.Image2.PixelWidth || h != Presenters.Image2.PixelHeight)
+            return;
+
+        _transitionHelper.Width = w;
+        _transitionHelper.Height = h;
+
+        byte[] result = Presenters.IsSmoothMode
+            ? _transitionHelper.MixSmooth(p1, p2)
+            : _transitionHelper.MixBricks(p1, p2);
+
+        var bmp = _mediaFactory.CreateBitmapFromRaw(w, h, true, result, w * 4);
+        Presenters.ResultImage = _mediaFactory.CloneBitmap(bmp);
+
+        if (!Presenters.IsSmoothMode)
+        {
+            byte[] mapData = _transitionHelper.GetLabelMap();
+            if (mapData.Length > 0)
+            {
+                var labelBmp = _mediaFactory.CreateEmptyBitmap(w, h, true);
+                labelBmp.WritePixels(new PixelRect(0, 0, w, h), mapData, w * 4);
+                Presenters.LabelMapImage = labelBmp;
+            }
+        }
     }
 }

--- a/TgaBuilderLib/ViewModel/Views/ModificationsViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/ModificationsViewModel.cs
@@ -1,20 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
+using System.ComponentModel;
 using System.Windows.Input;
 using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.BitmapOperations;
 using TgaBuilderLib.Commands;
-using TgaBuilderLib.Enums;
 using TgaBuilderLib.Modifications;
 using TgaBuilderLib.ViewModel.Modifications;
 
 namespace TgaBuilderLib.ViewModel;
-
-// =========================================================================
-// ModificationsViewModel — flat standalone class
-// =========================================================================
 
 public class ModificationsViewModel : ViewModelBase
 {
@@ -38,25 +30,15 @@ public class ModificationsViewModel : ViewModelBase
         ColorVM = color;
         ColorOverlayVM = colorOverlay;
 
-        _inputImage = _mediaFactory.CreateEmptyBitmap(42, 42, true);
-        _resultImage = _mediaFactory.CreateEmptyBitmap(42, 42, true);
-        _inputPixels = new byte[42];
+        Presenters.PropertyChanged += OnPresentersPropertyChanged;
 
         LoadInputImage();
     }
-
-    // =====================================================================
-    // Infrastructure
-    // =====================================================================
 
     private readonly IMediaFactory _mediaFactory;
     private readonly IModificationsHelper _modificationsHelper;
     private readonly IBitmapOperations _bitmapOperations;
     private readonly MainViewModel _mainViewModel;
-
-    // =====================================================================
-    // Child View Models
-    // =====================================================================
 
     public ModificationsPresentersViewModel Presenters { get; }
     public ModificationsBasicViewModel BasicVM { get; }
@@ -65,40 +47,23 @@ public class ModificationsViewModel : ViewModelBase
 
     private const int BPP = 4;
 
-    private readonly object _recalcLock = new();
-    private bool _recalcRunning;
-    private bool _recalcPending;
-
-    // =====================================================================
-    // Images and pixel buffers
-    // =====================================================================
-
-    private IWriteableBitmap _inputImage;
-    private IWriteableBitmap _resultImage;
-    private byte[] _inputPixels;
-    private bool _initTextVisible = true;
-
     public IWriteableBitmap InputImage
     {
-        get => _inputImage;
-        set => SetCallerProperty(ref _inputImage, value);
+        get => Presenters.InputImage;
+        set => Presenters.InputImage = value;
     }
 
     public IWriteableBitmap ResultImage
     {
-        get => _resultImage;
-        set => SetCallerProperty(ref _resultImage, value);
+        get => Presenters.ResultImage;
+        set => Presenters.ResultImage = value;
     }
 
     public bool InitTextVisible
     {
-        get => _initTextVisible;
-        set => SetCallerProperty(ref _initTextVisible, value);
+        get => Presenters.InitTextVisible;
+        set => Presenters.InitTextVisible = value;
     }
-
-    // =====================================================================
-    // Commands
-    // =====================================================================
 
     private RelayCommand? _loadInputImageCommand;
     private RelayCommand<(int X, int Y)>? _mouseOverInputCommand;
@@ -113,216 +78,25 @@ public class ModificationsViewModel : ViewModelBase
     public ICommand CancelCommand => _cancelCommand ??= new RelayCommand<IView>(Cancel);
     public ICommand OKCommand => _oKCommand ??= new RelayCommand<IView>(OK);
 
-    // =====================================================================
-    // Basic adjustments
-    // Exposure:    -5 .. +5 (stops)
-    // Brightness:  -1 .. +1
-    // Contrast:    -1 .. +1
-    // Highlights:  -1 .. +1
-    // Shadows:     -1 .. +1
-    // Whites:      -1 .. +1
-    // Blacks:      -1 .. +1
-    // =====================================================================
-
-    private float _exposure = 0f;
-    private float _brightness = 0f;
-    private float _contrast = 0f;
-    private float _highlights = 0f;
-    private float _shadows = 0f;
-    private float _whites = 0f;
-    private float _blacks = 0f;
-
-    public float Exposure
-    {
-        get => _exposure;
-        set => SetPropertyTriggerRecalculation(ref _exposure, value);
-    }
-
-    public float Brightness
-    {
-        get => _brightness;
-        set => SetPropertyTriggerRecalculation(ref _brightness, value);
-    }
-
-    public float Contrast
-    {
-        get => _contrast;
-        set => SetPropertyTriggerRecalculation(ref _contrast, value);
-    }
-
-    public float Highlights
-    {
-        get => _highlights;
-        set => SetPropertyTriggerRecalculation(ref _highlights, value);
-    }
-
-    public float Shadows
-    {
-        get => _shadows;
-        set => SetPropertyTriggerRecalculation(ref _shadows, value);
-    }
-
-    public float Whites
-    {
-        get => _whites;
-        set => SetPropertyTriggerRecalculation(ref _whites, value);
-    }
-
-    public float Blacks
-    {
-        get => _blacks;
-        set => SetPropertyTriggerRecalculation(ref _blacks, value);
-    }
-
-    // =====================================================================
-    // Color adjustments
-    // Saturation:   -1 .. +1
-    // Vibrance:     -1 .. +1
-    // Hue:          -180 .. +180 (degrees)
-    // Temperature:  -1 .. +1
-    // Tint:         -1 .. +1
-    // =====================================================================
-
-    private float _saturation = 0f;
-    private float _vibrance = 0f;
-    private float _hue = 0f;
-    private float _temperature = 0f;
-    private float _tint = 0f;
-    private Color _colorOverlay = new(0, 0, 0, 0);
-    private float _colorOverlayAmount = 0f;
-    private int _selectedColorOverlayMixModeIndex = (int)ColorOverlayMixMode.OklabChroma;
-    private float _colorOverlaySoftLightStrength = 1f;
-    private float _colorOverlayLumaPreservation = 1f;
-    private float _colorOverlayChromaBoost = 1f;
-    private bool _isColorOverlayEyedropperMode;
-
-    public float Saturation
-    {
-        get => _saturation;
-        set => SetPropertyTriggerRecalculation(ref _saturation, value);
-    }
-
-    public float Vibrance
-    {
-        get => _vibrance;
-        set => SetPropertyTriggerRecalculation(ref _vibrance, value);
-    }
-
-    public float Hue
-    {
-        get => _hue;
-        set => SetPropertyTriggerRecalculation(ref _hue, value);
-    }
-
-    public float Temperature
-    {
-        get => _temperature;
-        set => SetPropertyTriggerRecalculation(ref _temperature, value);
-    }
-
-    public float Tint
-    {
-        get => _tint;
-        set => SetPropertyTriggerRecalculation(ref _tint, value);
-    }
-
-    public Color ColorOverlay
-    {
-        get => _colorOverlay;
-        set => SetPropertyTriggerRecalculation(ref _colorOverlay, value);
-    }
-
-    public float ColorOverlayAmount
-    {
-        get => _colorOverlayAmount;
-        set
-        {
-            float clamped = Math.Clamp(value, 0f, 1f);
-            if (Math.Abs(_colorOverlayAmount - clamped) > float.Epsilon)
-            {
-                _colorOverlayAmount = clamped;
-                OnPropertyChanged(nameof(ColorOverlayAmount));
-                OnPropertyChanged(nameof(ColorOverlayBlendPercent));
-                _ = TriggerRecalculation();
-            }
-        }
-    }
-
-    public float ColorOverlayBlendPercent
-    {
-        get => _colorOverlayAmount * 100f;
-        set => ColorOverlayAmount = Math.Clamp(value, 0f, 100f) / 100f;
-    }
-
-    public int SelectedColorOverlayMixModeIndex
-    {
-        get => _selectedColorOverlayMixModeIndex;
-        set
-        {
-            if (_selectedColorOverlayMixModeIndex != value)
-            {
-                _selectedColorOverlayMixModeIndex = value;
-                OnPropertyChanged(nameof(SelectedColorOverlayMixModeIndex));
-                OnPropertyChanged(nameof(IsColorOverlaySoftLightMode));
-                OnPropertyChanged(nameof(IsColorOverlayOklabMode));
-                _ = TriggerRecalculation();
-            }
-        }
-    }
-
-    public float ColorOverlaySoftLightStrength
-    {
-        get => _colorOverlaySoftLightStrength;
-        set => SetPropertyTriggerRecalculation(ref _colorOverlaySoftLightStrength, value);
-    }
-
-    public float ColorOverlayLumaPreservation
-    {
-        get => _colorOverlayLumaPreservation;
-        set => SetPropertyTriggerRecalculation(ref _colorOverlayLumaPreservation, value);
-    }
-
-    public float ColorOverlayChromaBoost
-    {
-        get => _colorOverlayChromaBoost;
-        set => SetPropertyTriggerRecalculation(ref _colorOverlayChromaBoost, value);
-    }
-
-    public bool IsColorOverlaySoftLightMode
-        => SelectedColorOverlayMixModeIndex == (int)ColorOverlayMixMode.SoftLight;
-
-    public bool IsColorOverlayOklabMode
-        => SelectedColorOverlayMixModeIndex == (int)ColorOverlayMixMode.OklabChroma;
-
-    public bool IsColorOverlayEyedropperMode
-    {
-        get => _isColorOverlayEyedropperMode;
-        set => SetCallerProperty(ref _isColorOverlayEyedropperMode, value);
-    }
-
-    // =====================================================================
-    // Actions
-    // =====================================================================
-
     private void LoadInputImage()
     {
-        InputImage = _mainViewModel.Selection.Presenter.HasAlpha
+        Presenters.InputImage = _mainViewModel.Selection.Presenter.HasAlpha
             ? _mediaFactory.CloneBitmap(_mainViewModel.Selection.Presenter)
             : _bitmapOperations.ConvertRGB24ToBGRA32(_mainViewModel.Selection.Presenter);
 
-        _inputPixels = new byte[InputImage.PixelWidth * InputImage.PixelHeight * BPP];
-        InputImage.CopyPixels(_inputPixels, InputImage.PixelWidth * BPP, 0);
-        InitTextVisible = false;
+        Presenters.InputPixels = new byte[Presenters.InputImage.PixelWidth * Presenters.InputImage.PixelHeight * BPP];
+        Presenters.InputImage.CopyPixels(Presenters.InputPixels, Presenters.InputImage.PixelWidth * BPP, 0);
+        Presenters.InitTextVisible = false;
 
-        _ = TriggerRecalculation();
+        BasicVM.RequestRecalculation();
     }
 
     private void MouseOverInput(int x, int y)
     {
-        if (!IsColorOverlayEyedropperMode)
+        if (!ColorOverlayVM.IsColorOverlayEyedropperMode)
             return;
 
-        ColorOverlay = _bitmapOperations.GetPixelBrush(InputImage, x, y);
+        ColorOverlayVM.ColorOverlay = _bitmapOperations.GetPixelBrush(InputImage, x, y);
     }
 
     private void Apply()
@@ -347,112 +121,24 @@ public class ModificationsViewModel : ViewModelBase
 
     public void MarkFinished()
     {
+        Presenters.PropertyChanged -= OnPresentersPropertyChanged;
         _modificationsHelper.CleanUp();
         _mainViewModel.IsModificationsViewOpen = false;
     }
 
-    // =====================================================================
-    // Recalculation pipeline
-    // =====================================================================
-
-    private void ConfigureHelper()
+    private void OnPresentersPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        _modificationsHelper.Width = InputImage.PixelWidth;
-        _modificationsHelper.Height = InputImage.PixelHeight;
-
-        _modificationsHelper.Exposure = _exposure;
-        _modificationsHelper.Brightness = _brightness;
-        _modificationsHelper.Contrast = _contrast;
-        _modificationsHelper.Highlights = _highlights;
-        _modificationsHelper.Shadows = _shadows;
-        _modificationsHelper.Whites = _whites;
-        _modificationsHelper.Blacks = _blacks;
-
-        _modificationsHelper.Saturation = _saturation;
-        _modificationsHelper.Vibrance = _vibrance;
-        _modificationsHelper.Hue = _hue;
-        _modificationsHelper.Temperature = _temperature;
-        _modificationsHelper.Tint = _tint;
-
-        _modificationsHelper.ColorOverlay = _colorOverlay;
-        _modificationsHelper.ColorOverlayAmount = _colorOverlayAmount;
-        _modificationsHelper.ColorOverlayMixMode = (ColorOverlayMixMode)Math.Clamp(
-            _selectedColorOverlayMixModeIndex,
-            (int)ColorOverlayMixMode.Linear,
-            (int)ColorOverlayMixMode.OklabChroma);
-        _modificationsHelper.ColorOverlaySoftLightStrength = _colorOverlaySoftLightStrength;
-        _modificationsHelper.ColorOverlayLumaPreservation = _colorOverlayLumaPreservation;
-        _modificationsHelper.ColorOverlayChromaBoost = _colorOverlayChromaBoost;
-    }
-
-    private async Task TriggerRecalculation()
-    {
-        lock (_recalcLock)
+        switch (e.PropertyName)
         {
-            if (_recalcRunning)
-            {
-                _recalcPending = true;
-                return;
-            }
-
-            _recalcRunning = true;
-        }
-
-        try
-        {
-            do
-            {
-                lock (_recalcLock)
-                {
-                    _recalcPending = false;
-                }
-
-                if (_inputPixels.Length == 0 || InputImage.PixelWidth == 0)
-                    return;
-
-                int width = InputImage.PixelWidth;
-                int height = InputImage.PixelHeight;
-
-                await Task.Delay(50);
-
-                ConfigureHelper();
-
-                byte[] inputCopy = new byte[_inputPixels.Length];
-                Array.Copy(_inputPixels, inputCopy, _inputPixels.Length);
-
-                byte[] resultPixels = await Task.Run(
-                    () => _modificationsHelper.Apply(inputCopy));
-
-                var resImage = _mediaFactory.CreateBitmapFromRaw(
-                    width,
-                    height,
-                    hasAlpha: true,
-                    resultPixels,
-                    stride: width * BPP);
-
-                ResultImage = _mediaFactory.CloneBitmap(resImage);
-            }
-            while (_recalcPending);
-        }
-        finally
-        {
-            lock (_recalcLock)
-            {
-                _recalcRunning = false;
-            }
-        }
-    }
-
-    private void SetPropertyTriggerRecalculation<T>(
-        ref T field,
-        T value,
-        [CallerMemberName] string? propertyName = null)
-    {
-        if (!EqualityComparer<T>.Default.Equals(field, value))
-        {
-            field = value;
-            OnPropertyChanged(propertyName ?? string.Empty);
-            _ = TriggerRecalculation();
+            case nameof(ModificationsPresentersViewModel.InputImage):
+                OnPropertyChanged(nameof(InputImage));
+                break;
+            case nameof(ModificationsPresentersViewModel.ResultImage):
+                OnPropertyChanged(nameof(ResultImage));
+                break;
+            case nameof(ModificationsPresentersViewModel.InitTextVisible):
+                OnPropertyChanged(nameof(InitTextVisible));
+                break;
         }
     }
 }

--- a/TgaBuilderLib/ViewModel/Views/ModificationsViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/ModificationsViewModel.cs
@@ -8,6 +8,7 @@ using TgaBuilderLib.BitmapOperations;
 using TgaBuilderLib.Commands;
 using TgaBuilderLib.Enums;
 using TgaBuilderLib.Modifications;
+using TgaBuilderLib.ViewModel.Modifications;
 
 namespace TgaBuilderLib.ViewModel;
 
@@ -21,12 +22,21 @@ public class ModificationsViewModel : ViewModelBase
         IMediaFactory mediaFactory,
         IModificationsHelper modificationsHelper,
         IBitmapOperations bitmapOperations,
-        MainViewModel mainViewModel)
+        MainViewModel mainViewModel,
+        ModificationsPresentersViewModel presenters,
+        ModificationsBasicViewModel basic,
+        ModificationsColorViewModel color,
+        ModificationsColorOverlayViewModel colorOverlay)
     {
         _mediaFactory = mediaFactory;
         _modificationsHelper = modificationsHelper;
         _bitmapOperations = bitmapOperations;
         _mainViewModel = mainViewModel;
+
+        Presenters = presenters;
+        BasicVM = basic;
+        ColorVM = color;
+        ColorOverlayVM = colorOverlay;
 
         _inputImage = _mediaFactory.CreateEmptyBitmap(42, 42, true);
         _resultImage = _mediaFactory.CreateEmptyBitmap(42, 42, true);
@@ -43,6 +53,15 @@ public class ModificationsViewModel : ViewModelBase
     private readonly IModificationsHelper _modificationsHelper;
     private readonly IBitmapOperations _bitmapOperations;
     private readonly MainViewModel _mainViewModel;
+
+    // =====================================================================
+    // Child View Models
+    // =====================================================================
+
+    public ModificationsPresentersViewModel Presenters { get; }
+    public ModificationsBasicViewModel BasicVM { get; }
+    public ModificationsColorViewModel ColorVM { get; }
+    public ModificationsColorOverlayViewModel ColorOverlayVM { get; }
 
     private const int BPP = 4;
 
@@ -328,6 +347,7 @@ public class ModificationsViewModel : ViewModelBase
 
     public void MarkFinished()
     {
+        _modificationsHelper.CleanUp();
         _mainViewModel.IsModificationsViewOpen = false;
     }
 

--- a/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
@@ -1,7 +1,5 @@
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using TgaBuilderLib.Abstraction;
@@ -57,12 +55,18 @@ public class TransitionViewModel : ViewModelBase
         Shadow = shadow;
         Manual = manual;
 
-        _image1 = _mediaFactory.CreateEmptyBitmap(64, 64, true);
-        _image2 = _mediaFactory.CreateEmptyBitmap(64, 64, true);
-        _resultImage = _mediaFactory.CreateEmptyBitmap(64, 64, true);
-
         _pixels1 = new byte[64 * 64 * 4];
         _pixels2 = new byte[64 * 64 * 4];
+
+        Presenters.Pixels1 = _pixels1;
+        Presenters.Pixels2 = _pixels2;
+        Presenters.IsSmoothMode = IsSmoothMode;
+        Presenters.PropertyChanged += Presenters_PropertyChanged;
+
+        Edge.PropertyChanged += Edge_PropertyChanged;
+        Shadow.PropertyChanged += Shadow_PropertyChanged;
+
+        SyncSharedControlsFromActiveChild();
     }
 
     // =====================================================================
@@ -97,13 +101,9 @@ public class TransitionViewModel : ViewModelBase
     // Images and pixel buffers
     // =====================================================================
 
-    private IWriteableBitmap _image1;
-    private IWriteableBitmap _image2;
-    private IWriteableBitmap _resultImage;
     private byte[] _pixels1;
     private byte[] _pixels2;
-
-    private bool _initTextVisible = true;
+    private bool _isLabelMapExpanded;
 
     public IVisualInvalidator? VisualInvalidator { get; set; }
 
@@ -112,26 +112,78 @@ public class TransitionViewModel : ViewModelBase
 
     public IWriteableBitmap Image1
     {
-        get => _image1;
-        set => SetCallerProperty(ref _image1, value);
+        get => Presenters.Image1;
+        set
+        {
+            Presenters.Image1 = value;
+            OnPropertyChanged(nameof(Image1));
+        }
     }
 
     public IWriteableBitmap Image2
     {
-        get => _image2;
-        set => SetCallerProperty(ref _image2, value);
+        get => Presenters.Image2;
+        set
+        {
+            Presenters.Image2 = value;
+            OnPropertyChanged(nameof(Image2));
+        }
     }
 
     public IWriteableBitmap ResultImage
     {
-        get => _resultImage;
-        set => SetCallerProperty(ref _resultImage, value);
+        get => Presenters.ResultImage;
+        set
+        {
+            Presenters.ResultImage = value;
+            OnPropertyChanged(nameof(ResultImage));
+        }
     }
 
     public bool InitTextVisible
     {
-        get => _initTextVisible;
-        set => SetCallerProperty(ref _initTextVisible, value);
+        get => Presenters.InitTextVisible;
+        set
+        {
+            Presenters.InitTextVisible = value;
+            OnPropertyChanged(nameof(InitTextVisible));
+        }
+    }
+
+    public IWriteableBitmap? LabelMapImage
+    {
+        get => Presenters.LabelMapImage;
+        set
+        {
+            Presenters.LabelMapImage = value;
+            OnPropertyChanged(nameof(LabelMapImage));
+        }
+    }
+
+    public IWriteableBitmap? IndicatorMapImage
+    {
+        get => Presenters.IndicatorMapImage;
+        set
+        {
+            Presenters.IndicatorMapImage = value;
+            OnPropertyChanged(nameof(IndicatorMapImage));
+        }
+    }
+
+    public bool IsIndicatorMapVisible
+    {
+        get => Presenters.IsIndicatorMapVisible;
+        set
+        {
+            Presenters.IsIndicatorMapVisible = value;
+            OnPropertyChanged(nameof(IsIndicatorMapVisible));
+        }
+    }
+
+    public bool IsLabelMapExpanded
+    {
+        get => _isLabelMapExpanded;
+        set => SetCallerProperty(ref _isLabelMapExpanded, value);
     }
 
     // =====================================================================
@@ -146,7 +198,7 @@ public class TransitionViewModel : ViewModelBase
     private RelayCommand? _resetExplicitVisibilityCommand;
     private RelayCommand<(int, int)>? _requestLabelIndicatorCommand;
     private RelayCommand? _markFinishedCommand;
-    private RelayCommand? _applyCommand; 
+    private RelayCommand? _applyCommand;
     private RelayCommand<IView>? _cancelCommand;
     private RelayCommand<IView>? _oKCommand;
 
@@ -155,7 +207,7 @@ public class TransitionViewModel : ViewModelBase
     public ICommand LoadImage2Command => _loadImage2Command ??= new RelayCommand(LoadImage2);
     public ICommand SwapImagesCommand => _swapImagesCommand ??= new RelayCommand(SwapImages);
     public ICommand SetExplicitTileVisibilityCommand => _setExplicitTileVisibilityCommand
-        ??= new RelayCommand<(int, int)>(args => 
+        ??= new RelayCommand<(int, int)>(args =>
         SetExplicitTileVisibility(args.Item1, args.Item2));
     public ICommand ResetExplicitVisibilityCommand => _resetExplicitVisibilityCommand
         ??= new RelayCommand(ResetAllExplicitTileVisibility);
@@ -172,37 +224,43 @@ public class TransitionViewModel : ViewModelBase
 
     private TransitionMode _selectedTransitionMode = TransitionMode.Top;
     private float _pivotValue = 0.5f;
-    private float _wideningValue = 0f;
-    private float _shiftValue = 0f;
     private Color _colorSource = new(0, 0, 0, 0);
     private Color _colorTarget = new(0, 0, 0, 0);
 
     public TransitionMode SelectedTransitionMode
     {
         get => _selectedTransitionMode;
-        set => SetPropertyTriggerRecalculation(ref _selectedTransitionMode, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding);
+        set
+        {
+            if (_selectedTransitionMode == value)
+                return;
+
+            _selectedTransitionMode = value;
+            OnPropertyChanged(nameof(SelectedTransitionMode));
+
+            if (IsSmoothMode)
+                PivotSmooth.SelectedTransitionMode = value;
+            else
+                PivotBricks.SelectedTransitionMode = value;
+        }
     }
 
     public float PivotValue
     {
         get => _pivotValue;
-        set => SetPropertyTriggerRecalculation(ref _pivotValue, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding);
-    }
+        set
+        {
+            if (_pivotValue == value)
+                return;
 
-    public float WideningValue
-    {
-        get => _wideningValue;
-        set => SetPropertyTriggerRecalculation(ref _wideningValue, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding);
-    }
+            _pivotValue = value;
+            OnPropertyChanged(nameof(PivotValue));
 
-    public float ShiftValue
-    {
-        get => _shiftValue;
-        set => SetPropertyTriggerRecalculation(ref _shiftValue, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding);
+            if (IsSmoothMode)
+                PivotSmooth.PivotValue = value;
+            else
+                PivotBricks.PivotValue = value;
+        }
     }
 
     public Color ColorSource
@@ -228,27 +286,31 @@ public class TransitionViewModel : ViewModelBase
         get => _selectedTransitionType;
         set
         {
-            if (_selectedTransitionType != value)
+            if (_selectedTransitionType == value)
+                return;
+
+            _selectedTransitionType = value;
+            OnPropertyChanged(nameof(SelectedTransitionType));
+            OnPropertyChanged(nameof(IsSmoothMode));
+            OnPropertyChanged(nameof(IsBrickMode));
+
+            Presenters.IsSmoothMode = IsSmoothMode;
+            SyncSharedControlsFromActiveChild();
+
+            if (IsBrickMode)
+                _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresAnalysis;
+
+            if (IsSmoothMode)
             {
-                _selectedTransitionType = value;
-                OnPropertyChanged(nameof(SelectedTransitionType));
-                OnPropertyChanged(nameof(IsSmoothMode));
-                OnPropertyChanged(nameof(IsBrickMode));
-
-                if (_selectedTransitionType == TransitionType.Bricks)
-                    _currentRequirements = BricksPipelineRequirements.RequiresAnalysis;
-
-                if (_selectedTransitionType == TransitionType.Smooth)
-                {
-                    IsLabelMapExpanded = false;
-                    IsExplicitTileVisibilityEraseMode = false;
-                    IsExplicitTileVisibilityDrawMode = false;
-                    IsEyedropperMode = false;
-                    IsShadowEyedropperMode = false;
-                }
-
-                _ = TriggerRecalculation();
+                IsLabelMapExpanded = false;
+                Manual.IsExplicitTileVisibilityEraseMode = false;
+                Manual.IsExplicitTileVisibilityDrawMode = false;
+                Edge.IsEyedropperMode = false;
+                Shadow.IsShadowEyedropperMode = false;
+                IsIndicatorMapVisible = false;
             }
+
+            _ = TriggerRecalculation();
         }
     }
 
@@ -256,399 +318,24 @@ public class TransitionViewModel : ViewModelBase
     public bool IsSmoothMode => _selectedTransitionType == TransitionType.Smooth;
     public bool IsBrickMode => _selectedTransitionType == TransitionType.Bricks;
 
-    // =====================================================================
-    // Smooth-mode properties
-    // =====================================================================
-
-    private float _blendHardnessValue = 0.5f;
-
-    public float BlendHardnessValue
-    {
-        get => _blendHardnessValue;
-        set => SetPropertyTriggerRecalculation(ref _blendHardnessValue, value);
-    }
-
-    // =====================================================================
-    // Brick-mode properties
-    // =====================================================================
-
-    private IWriteableBitmap? _labelMapImage;
-    private IWriteableBitmap? _indicatorMapImage;
-    private bool _isIndicatorMapVisible;
-    private bool _invertGrayscale;
-    private int _markerCount = 42;
-    private int _markerRadius = 5;
-    private float _gridFitAngle = 0f;
-    private bool _reversePivot;
-    private bool _sliceCornerTiles;
-    private bool _protectEdges = true;
-    private bool _isLabelMapExpanded;
-    private FilterType _selectedFilter = FilterType.Gaussian;
-    private SegmentationMethod _selectedSegmentationMethod = SegmentationMethod.Felzenszwalb;
-    private int _felzenszwalbMinSize = 50;
-    private float _felzenszwalbScale = 100f;
-    private int _slicSegmentCount = 250;
-    private float _slicCompactness = 10f;
-    private int _quickshiftMaxDist = 10;
-    private float _quickshiftRatio = 1f;
-    private float _bilateralSigma = 30f;
-    private float _gaussianSigma = 1f;
-    private float _underfillingPivot = 0.5f;
-    private bool _reverseUnderfilling = false;
-    private int _underFillingThreshold = 0;
-    private Color _edgeColor = new Color(255, 255, 255, 128);
-    private Color _shadowColor = new Color(42, 42, 42, 42);
-    private EdgeBlendMode _blendMode = EdgeBlendMode.Multiply;
-    private int _edgeWidth = 1;
-    private int _shadowSize = 3;
-    private int _shadowHardness = 50;
-    private bool _isEyedropperMode;
-    private bool _isShadowEyedropperMode;
-    private bool _isExplicitTileVisibilityDrawMode;
-    private bool _isExplicitTileVisibilityEraseMode;
-    private BricksPipelineRequirements _currentRequirements = BricksPipelineRequirements.RequiresAnalysis;
-
     private RelayCommand<(int X, int Y, int imageNum)>? _mouseOverCommand;
-
-    public IWriteableBitmap? LabelMapImage
-    {
-        get => _labelMapImage;
-        set => SetCallerProperty(ref _labelMapImage, value);
-    }
-
-    public IWriteableBitmap? IndicatorMapImage
-    {
-        get => _indicatorMapImage;
-        set => SetCallerProperty(ref _indicatorMapImage, value);
-    }
-
-    public bool IsIndicatorMapVisible
-    {
-        get => _isIndicatorMapVisible;
-        set => SetCallerProperty(ref _isIndicatorMapVisible, value);
-    }
-
-    public bool InvertGrayscale
-    {
-        get => _invertGrayscale;
-        set => SetPropertyTriggerRecalculation(ref _invertGrayscale, value,
-            BricksPipelineRequirements.RequiresAnalysis, null);
-    }
-
-    public int MarkerCount
-    {
-        get => _markerCount;
-        set => SetPropertyTriggerRecalculation(ref _markerCount, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public int MarkerRadius
-    {
-        get => _markerRadius;
-        set => SetPropertyTriggerRecalculation(ref _markerRadius, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public float GridFitAngle
-    {
-        get => _gridFitAngle;
-        set => SetPropertyTriggerRecalculation(ref _gridFitAngle, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public bool ReversePivot
-    {
-        get => _reversePivot;
-        set => SetPropertyTriggerRecalculation(ref _reversePivot, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding, null);
-    }
-
-    public bool SliceCornerTiles
-    {
-        get => _sliceCornerTiles;
-        set => SetPropertyTriggerRecalculation(ref _sliceCornerTiles, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding, null);
-    }
-
-    public bool ProtectEdges
-    {
-        get => _protectEdges;
-        set => SetPropertyTriggerRecalculation(ref _protectEdges, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding, null);
-    }
-
-    public bool IsLabelMapExpanded
-    {
-        get => _isLabelMapExpanded;
-        set => SetCallerProperty(ref _isLabelMapExpanded, value);
-    }
-
-    public FilterType SelectedFilter
-    {
-        get => _selectedFilter;
-        set
-        {
-            if (SetCallerPropertyReturn(ref _selectedFilter, value, nameof(SelectedFilter)))
-            {
-                OnPropertyChanged(nameof(ShowBilateralSigma));
-                OnPropertyChanged(nameof(ShowGaussianSigma));
-                OnPropertyChanged(nameof(SelectedFilterIndex));
-                _currentRequirements = BricksPipelineRequirements.RequiresAnalysis;
-                _ = TriggerRecalculation();
-            }
-        }
-    }
-
-    public int SelectedFilterIndex
-    {
-        get => (int)_selectedFilter;
-        set => SelectedFilter = (FilterType)value;
-    }
-
-    public SegmentationMethod SelectedSegmentationMethod
-    {
-        get => _selectedSegmentationMethod;
-        set
-        {
-            if (SetCallerPropertyReturn(ref _selectedSegmentationMethod, value, nameof(SelectedSegmentationMethod)))
-            {
-                OnPropertyChanged(nameof(ShowFelzenszwalbParameters));
-                OnPropertyChanged(nameof(ShowSlicParameters));
-                OnPropertyChanged(nameof(ShowQuickshiftParameters));
-                OnPropertyChanged(nameof(ShowWatershedBasedSegmentationInputs));
-                OnPropertyChanged(nameof(ShowGridFittingSegmentationInputs));
-                OnPropertyChanged(nameof(SelectedSegmentationMethodIndex));
-                OnPropertyChanged(nameof(ShowGrayBasedSegmentationInputs));
-                _currentRequirements = BricksPipelineRequirements.RequiresAnalysis;
-                _ = TriggerRecalculation();
-            }
-        }
-    }
-
-    public bool ShowFelzenszwalbParameters => SelectedSegmentationMethod == SegmentationMethod.Felzenszwalb;
-    public bool ShowSlicParameters => SelectedSegmentationMethod == SegmentationMethod.Slic;
-    public bool ShowQuickshiftParameters => SelectedSegmentationMethod == SegmentationMethod.Quickshift;
-    public bool ShowBilateralSigma => SelectedFilter == FilterType.Bilateral;
-    public bool ShowGaussianSigma => SelectedFilter == FilterType.Gaussian;
-    public bool ShowWatershedBasedSegmentationInputs => SelectedSegmentationMethod == SegmentationMethod.Watershed;
-
-    public bool ShowGridFittingSegmentationInputs => 
-        SelectedSegmentationMethod == SegmentationMethod.BrickFit || 
-        SelectedSegmentationMethod == SegmentationMethod.GridFit;
-
-    public bool ShowGrayBasedSegmentationInputs =>
-        ShowWatershedBasedSegmentationInputs || ShowGridFittingSegmentationInputs;
-
-    public int FelzenszwalbMinSize
-    {
-        get => _felzenszwalbMinSize;
-        set => SetPropertyTriggerRecalculation(ref _felzenszwalbMinSize, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public float FelzenszwalbScale
-    {
-        get => _felzenszwalbScale;
-        set => SetPropertyTriggerRecalculation(ref _felzenszwalbScale, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public int SlicSegmentCount
-    {
-        get => _slicSegmentCount;
-        set => SetPropertyTriggerRecalculation(ref _slicSegmentCount, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public float SlicCompactness
-    {
-        get => _slicCompactness;
-        set => SetPropertyTriggerRecalculation(ref _slicCompactness, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public int QuickshiftMaxDist
-    {
-        get => _quickshiftMaxDist;
-        set => SetPropertyTriggerRecalculation(ref _quickshiftMaxDist, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public float QuickshiftRatio
-    {
-        get => _quickshiftRatio;
-        set => SetPropertyTriggerRecalculation(ref _quickshiftRatio, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public float BilateralSigma
-    {
-        get => _bilateralSigma;
-        set => SetPropertyTriggerRecalculation(ref _bilateralSigma, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public float GaussianSigma
-    {
-        get => _gaussianSigma;
-        set => SetPropertyTriggerRecalculation(ref _gaussianSigma, value,
-            BricksPipelineRequirements.RequiresAnalysis);
-    }
-
-    public float UnderfillingPivot
-    {
-        get => _underfillingPivot;
-        set => SetPropertyTriggerRecalculation(ref _underfillingPivot, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding);
-    }
-
-    public bool ReverseUnderfilling
-    {
-        get => _reverseUnderfilling;
-        set => SetPropertyTriggerRecalculation(ref _reverseUnderfilling, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding);
-    }
-
-    public int UnderfillingThreshold
-    {
-        get => _underFillingThreshold;
-        set => SetPropertyTriggerRecalculation(ref _underFillingThreshold, value,
-            BricksPipelineRequirements.RequiresSelectionBuilding);
-    }
-
-    public Color EdgeColor
-    {
-        get => _edgeColor;
-        set => SetPropertyTriggerRecalculation(ref _edgeColor, value,
-            BricksPipelineRequirements.RequiresDrawing);
-    }
-
-    public EdgeBlendMode BlendMode
-    {
-        get => _blendMode;
-        set => SetPropertyTriggerRecalculation(ref _blendMode, value,
-            BricksPipelineRequirements.RequiresDrawing);
-    }
-
-    public Array EdgeBlendModes => Enum.GetValues(typeof(EdgeBlendMode));
-
-    public Color ShadowColor
-    {
-        get => _shadowColor;
-        set => SetPropertyTriggerRecalculation(ref _shadowColor, value,
-            BricksPipelineRequirements.RequiresDrawing);
-    }
-
-    public int EdgeWidth
-    {
-        get => _edgeWidth;
-        set => SetPropertyTriggerRecalculation(ref _edgeWidth, value,
-            BricksPipelineRequirements.RequiresDrawing);
-    }
-
-    public int ShadowSize
-    {
-        get => _shadowSize;
-        set => SetPropertyTriggerRecalculation(ref _shadowSize, value,
-            BricksPipelineRequirements.RequiresDrawing);
-    }
-
-    public int ShadowHardness
-    {
-        get => _shadowHardness;
-        set => SetPropertyTriggerRecalculation(ref _shadowHardness, value,
-            BricksPipelineRequirements.RequiresDrawing);
-    }
-
-    public bool IsEyedropperMode
-    {
-        get => _isEyedropperMode;
-        set
-        {
-            if (_isEyedropperMode == value)
-                return;
-
-            _isEyedropperMode = value;
-            OnPropertyChanged(nameof(IsEyedropperMode));
-
-            if (!value)
-                return;
-
-            _isShadowEyedropperMode = false;
-            OnPropertyChanged(nameof(IsShadowEyedropperMode));
-        }
-    }
-
-    public bool IsShadowEyedropperMode
-    {
-        get => _isShadowEyedropperMode;
-        set
-        {
-            if (_isShadowEyedropperMode == value)
-                return;
-
-            _isShadowEyedropperMode = value;
-            OnPropertyChanged(nameof(IsShadowEyedropperMode));
-
-            if (!value)
-                return;
-
-            _isEyedropperMode = false;
-            OnPropertyChanged(nameof(IsEyedropperMode));
-        }
-    }
-
-    public bool IsExplicitTileVisibilityDrawMode
-    {
-        get => _isExplicitTileVisibilityDrawMode;
-        set
-        {
-            SetProperty(ref _isExplicitTileVisibilityDrawMode, value, nameof(IsExplicitTileVisibilityDrawMode));
-
-            if (!value) 
-                return;
-
-            _isExplicitTileVisibilityEraseMode = false;
-            OnPropertyChanged(nameof(IsExplicitTileVisibilityEraseMode));
-        }
-    }
-
-    public bool IsExplicitTileVisibilityEraseMode
-    {
-        get => _isExplicitTileVisibilityEraseMode;
-        set
-        {
-            SetProperty(ref _isExplicitTileVisibilityEraseMode, value, nameof(IsExplicitTileVisibilityEraseMode));
-            if (!value) 
-                return;
-
-            _isExplicitTileVisibilityDrawMode = false;
-            OnPropertyChanged(nameof(IsExplicitTileVisibilityDrawMode));
-        }
-    }
-
-    public int SelectedSegmentationMethodIndex
-    {
-        get => (int)_selectedSegmentationMethod;
-        set => SelectedSegmentationMethod = (SegmentationMethod)value;
-    }
 
     public ICommand MouseOverCommand => _mouseOverCommand
         ??= new RelayCommand<(int X, int Y, int imageNum)>(MouseOverImages);
 
     private void MouseOverImages((int X, int Y, int imageNum) args)
     {
-        if (IsEyedropperMode || IsShadowEyedropperMode)
-            DoColorPicking(args.X, args.Y, args.imageNum, IsShadowEyedropperMode);
+        if (Edge.IsEyedropperMode || Shadow.IsShadowEyedropperMode)
+            DoColorPicking(args.X, args.Y, args.imageNum, Shadow.IsShadowEyedropperMode);
     }
 
     private void DoColorPicking(int x, int y, int imageNum, bool pickShadowColor)
     {
         var sampledColor = _bitmapOperations.GetPixelBrush(imageNum == 1 ? Image1 : Image2, x, y);
         if (pickShadowColor)
-            ShadowColor = sampledColor;
+            Shadow.ShadowColor = sampledColor;
         else
-            EdgeColor = sampledColor;
+            Edge.EdgeColor = sampledColor;
     }
 
     // =====================================================================
@@ -664,50 +351,43 @@ public class TransitionViewModel : ViewModelBase
     {
         if (IsSmoothMode)
         {
-            _transitionHelper.Hardness = _blendHardnessValue;
+            _transitionHelper.Hardness = PivotSmooth.BlendHardnessValue;
         }
         else
         {
-            _transitionHelper.CurrentBricksPipelineRequirements = _currentRequirements;
-            _transitionHelper.InvertGrayscale = InvertGrayscale;
-            _transitionHelper.ReversePivot = ReversePivot;
-            _transitionHelper.SliceCornerTiles = SliceCornerTiles;
-            _transitionHelper.ProtectEdges = ProtectEdges;
-            _transitionHelper.MarkerCount = MarkerCount;
-            _transitionHelper.MarkerRadius = MarkerRadius;
-            _transitionHelper.GridFitAngle = GridFitAngle;
-            _transitionHelper.SelectedFilter = SelectedFilter;
-            _transitionHelper.SegmentationMethod = SelectedSegmentationMethod;
-            _transitionHelper.FelzenszwalbMinSize = FelzenszwalbMinSize;
-            _transitionHelper.FelzenszwalbScale = FelzenszwalbScale;
-            _transitionHelper.SlicSegmentCount = SlicSegmentCount;
-            _transitionHelper.SlicCompactness = SlicCompactness;
-            _transitionHelper.QuickshiftMaxDist = QuickshiftMaxDist;
-            _transitionHelper.QuickshiftRatio = QuickshiftRatio;
-            _transitionHelper.BilateralSigma = BilateralSigma;
-            _transitionHelper.GaussianSigma = GaussianSigma;
-            _transitionHelper.UnderfillingPivot = UnderfillingPivot;
-            _transitionHelper.ReverseUnderfilling = ReverseUnderfilling;
-            _transitionHelper.UnderfillingThreshold = UnderfillingThreshold;
-            _transitionHelper.EdgeColor = EdgeColor;
-            _transitionHelper.BlendMode = BlendMode;
-            _transitionHelper.EdgeWidth = EdgeWidth;
-            _transitionHelper.ShadowColor = ShadowColor;
-            _transitionHelper.ShadowSize = ShadowSize;
-            _transitionHelper.ShadowHardness = ShadowHardness;
+            _transitionHelper.InvertGrayscale = Analysis.InvertGrayscale;
+            _transitionHelper.ReversePivot = PivotBricks.ReversePivot;
+            _transitionHelper.SliceCornerTiles = PivotBricks.SliceCornerTiles;
+            _transitionHelper.ProtectEdges = PivotBricks.ProtectEdges;
+            _transitionHelper.MarkerCount = Analysis.MarkerCount;
+            _transitionHelper.MarkerRadius = Analysis.MarkerRadius;
+            _transitionHelper.GridFitAngle = Analysis.GridFitAngle;
+            _transitionHelper.SelectedFilter = Analysis.SelectedFilter;
+            _transitionHelper.SegmentationMethod = Analysis.SelectedSegmentationMethod;
+            _transitionHelper.FelzenszwalbMinSize = Analysis.FelzenszwalbMinSize;
+            _transitionHelper.FelzenszwalbScale = Analysis.FelzenszwalbScale;
+            _transitionHelper.SlicSegmentCount = Analysis.SlicSegmentCount;
+            _transitionHelper.SlicCompactness = Analysis.SlicCompactness;
+            _transitionHelper.QuickshiftMaxDist = Analysis.QuickshiftMaxDist;
+            _transitionHelper.QuickshiftRatio = Analysis.QuickshiftRatio;
+            _transitionHelper.BilateralSigma = Analysis.BilateralSigma;
+            _transitionHelper.GaussianSigma = Analysis.GaussianSigma;
+            _transitionHelper.UnderfillingPivot = Underfilling.UnderfillingPivot;
+            _transitionHelper.ReverseUnderfilling = Underfilling.ReverseUnderfilling;
+            _transitionHelper.UnderfillingThreshold = Underfilling.UnderfillingThreshold;
+            _transitionHelper.EdgeColor = Edge.EdgeColor;
+            _transitionHelper.BlendMode = Edge.BlendMode;
+            _transitionHelper.EdgeWidth = Edge.EdgeWidth;
+            _transitionHelper.ShadowColor = Shadow.ShadowColor;
+            _transitionHelper.ShadowSize = Shadow.ShadowSize;
+            _transitionHelper.ShadowHardness = Shadow.ShadowHardness;
         }
-    }
-
-    private void OnResultUpdated()
-    {
-        if (IsBrickMode)
-            UpdateLabelMapImage();
     }
 
     private void SwapImages()
     {
         if (IsBrickMode)
-            _currentRequirements = BricksPipelineRequirements.RequiresAnalysis;
+            _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresAnalysis;
 
         var tempImage = Image1;
         Image1 = Image2;
@@ -716,6 +396,8 @@ public class TransitionViewModel : ViewModelBase
         var tempPixels = _pixels1;
         _pixels1 = _pixels2;
         _pixels2 = tempPixels;
+        Presenters.Pixels1 = _pixels1;
+        Presenters.Pixels2 = _pixels2;
 
         _ = TriggerRecalculation();
     }
@@ -723,22 +405,13 @@ public class TransitionViewModel : ViewModelBase
     private void Mix()
     {
         if (IsBrickMode)
-            _currentRequirements = BricksPipelineRequirements.RequiresAnalysis;
+            _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresAnalysis;
 
         if (!CompareInputSpecs())
             return;
 
         ConfigureTransitionHelper(Image1.PixelWidth, Image1.PixelHeight);
-
-        var resultPixels = CreateMixedPixels();
-
-        ResultImage = _mediaFactory.CreateEmptyBitmap(Image1.PixelWidth, Image1.PixelHeight, Image1.HasAlpha);
-        ResultImage.WritePixels(
-            new PixelRect(0, 0, ResultImage.PixelWidth, ResultImage.PixelHeight),
-            resultPixels,
-            ResultImage.PixelWidth * TRANSITIONS_BPP);
-
-        OnResultUpdated();
+        UpdateResultImages(Image1.PixelWidth, Image1.PixelHeight, CreateMixedPixels());
     }
 
     private void LoadImage1()
@@ -749,6 +422,7 @@ public class TransitionViewModel : ViewModelBase
 
         _pixels1 = new byte[Image1.PixelWidth * Image1.PixelHeight * TRANSITIONS_BPP];
         Image1.CopyPixels(_pixels1, Image1.PixelWidth * TRANSITIONS_BPP, 0);
+        Presenters.Pixels1 = _pixels1;
         InitTextVisible = false;
 
         _transitionHelper.CleanUp();
@@ -762,6 +436,7 @@ public class TransitionViewModel : ViewModelBase
 
         _pixels2 = new byte[Image2.PixelWidth * Image2.PixelHeight * TRANSITIONS_BPP];
         Image2.CopyPixels(_pixels2, Image2.PixelWidth * TRANSITIONS_BPP, 0);
+        Presenters.Pixels2 = _pixels2;
         InitTextVisible = false;
 
         _transitionHelper.CleanUp();
@@ -776,11 +451,10 @@ public class TransitionViewModel : ViewModelBase
     {
         _transitionHelper.Width = width;
         _transitionHelper.Height = height;
-
         _transitionHelper.Mode = SelectedTransitionMode;
         _transitionHelper.Pivot = PivotValue;
-        _transitionHelper.Widening = WideningValue;
-        _transitionHelper.Shift = ShiftValue;
+        _transitionHelper.Widening = IsSmoothMode ? PivotSmooth.WideningValue : PivotBricks.WideningValue;
+        _transitionHelper.Shift = IsSmoothMode ? PivotSmooth.ShiftValue : PivotBricks.ShiftValue;
 
         ConfigureTransitionHelperCore();
     }
@@ -811,22 +485,20 @@ public class TransitionViewModel : ViewModelBase
         view.CloseAsync();
     }
 
-    private void UpdateLabelMapImage()
+    private void UpdateResultImages(int width, int height, byte[] resultPixels)
     {
-        byte[] mapData = _transitionHelper.GetLabelMap();
+        var resultBitmap = _mediaFactory.CreateBitmapFromRaw(width, height, true, resultPixels, width * 4);
+        ResultImage = _mediaFactory.CloneBitmap(resultBitmap);
 
-        int mapW = ResultImage?.PixelWidth ?? 0;
-        int mapH = ResultImage?.PixelHeight ?? 0;
-
-        if (mapData.Length == 0 || mapW == 0 || mapH == 0)
+        if (IsSmoothMode)
             return;
 
-        var labelBmp = _mediaFactory.CreateEmptyBitmap(mapW, mapH, true);
-        labelBmp.WritePixels(
-            new PixelRect(0, 0, mapW, mapH),
-            mapData,
-            mapW * 4);
+        byte[] mapData = _transitionHelper.GetLabelMap();
+        if (mapData.Length == 0)
+            return;
 
+        var labelBmp = _mediaFactory.CreateEmptyBitmap(width, height, true);
+        labelBmp.WritePixels(new PixelRect(0, 0, width, height), mapData, width * 4);
         LabelMapImage = labelBmp;
     }
 
@@ -856,7 +528,7 @@ public class TransitionViewModel : ViewModelBase
 
     private void SetExplicitTileVisibility(int x, int y)
     {
-        if(!IsExplicitTileVisibilityEraseMode && !IsExplicitTileVisibilityDrawMode)
+        if (!Manual.IsExplicitTileVisibilityEraseMode && !Manual.IsExplicitTileVisibilityDrawMode)
             return;
 
         int label = _transitionHelper.GetLabelAtPixel(x, y);
@@ -864,20 +536,17 @@ public class TransitionViewModel : ViewModelBase
         if (label == 0)
             return;
 
-        bool visibikityChnaged = _transitionHelper.SetExplicitTileVisibility(label, IsExplicitTileVisibilityDrawMode);
+        bool visibilityChanged = _transitionHelper.SetExplicitTileVisibility(label, Manual.IsExplicitTileVisibilityDrawMode);
+        _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresSelectionBuilding;
 
-        _currentRequirements = BricksPipelineRequirements.RequiresSelectionBuilding;
-
-        if (visibikityChnaged)
+        if (visibilityChanged)
             _ = TriggerRecalculation();
     }
 
     private void ResetAllExplicitTileVisibility()
     {
         _transitionHelper.ResetAllExplicitTileVisibility();
-
-        _currentRequirements = BricksPipelineRequirements.RequiresSelectionBuilding;
-
+        _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresSelectionBuilding;
         _ = TriggerRecalculation();
     }
 
@@ -917,19 +586,8 @@ public class TransitionViewModel : ViewModelBase
 
                 ConfigureTransitionHelper(width, height);
 
-                byte[] resultPixels = await Task.Run(
-                    () => CreateMixedPixels());
-
-                var resImage = _mediaFactory.CreateBitmapFromRaw(
-                    width,
-                    height,
-                    hasAlpha: true,
-                    resultPixels,
-                    stride: width * 4);
-
-                ResultImage = _mediaFactory.CloneBitmap(resImage);
-
-                OnResultUpdated();
+                byte[] resultPixels = await Task.Run(CreateMixedPixels);
+                UpdateResultImages(width, height, resultPixels);
             }
             while (_pivotUpdatePending);
         }
@@ -942,46 +600,60 @@ public class TransitionViewModel : ViewModelBase
         }
     }
 
-    private void SetPropertyTriggerRecalculation<T>(
-        ref T field,
-        T value,
-        [CallerMemberName] string? propertyName = null)
+    private void SyncSharedControlsFromActiveChild()
     {
-        if (!EqualityComparer<T>.Default.Equals(field, value))
+        if (IsSmoothMode)
         {
-            field = value;
-            OnPropertyChanged(propertyName ?? string.Empty);
-            _ = TriggerRecalculation();
+            _selectedTransitionMode = PivotSmooth.SelectedTransitionMode;
+            _pivotValue = PivotSmooth.PivotValue;
+        }
+        else
+        {
+            _selectedTransitionMode = PivotBricks.SelectedTransitionMode;
+            _pivotValue = PivotBricks.PivotValue;
+        }
+
+        OnPropertyChanged(nameof(SelectedTransitionMode));
+        OnPropertyChanged(nameof(PivotValue));
+    }
+
+    private void Presenters_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        switch (e.PropertyName)
+        {
+            case nameof(TransitionPresentersViewModel.Image1):
+                OnPropertyChanged(nameof(Image1));
+                break;
+            case nameof(TransitionPresentersViewModel.Image2):
+                OnPropertyChanged(nameof(Image2));
+                break;
+            case nameof(TransitionPresentersViewModel.ResultImage):
+                OnPropertyChanged(nameof(ResultImage));
+                break;
+            case nameof(TransitionPresentersViewModel.LabelMapImage):
+                OnPropertyChanged(nameof(LabelMapImage));
+                break;
+            case nameof(TransitionPresentersViewModel.IndicatorMapImage):
+                OnPropertyChanged(nameof(IndicatorMapImage));
+                break;
+            case nameof(TransitionPresentersViewModel.IsIndicatorMapVisible):
+                OnPropertyChanged(nameof(IsIndicatorMapVisible));
+                break;
+            case nameof(TransitionPresentersViewModel.InitTextVisible):
+                OnPropertyChanged(nameof(InitTextVisible));
+                break;
         }
     }
 
-    private void SetPropertyTriggerRecalculation<T>(
-        ref T field,
-        T value,
-        BricksPipelineRequirements requirements,
-        [CallerMemberName] string? propertyName = null)
+    private void Edge_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (!EqualityComparer<T>.Default.Equals(field, value))
-        {
-            field = value;
-            _currentRequirements = requirements;
-
-            if (!string.IsNullOrEmpty(propertyName))
-                OnPropertyChanged(propertyName);
-
-            _ = TriggerRecalculation();
-        }
+        if (e.PropertyName == nameof(TransitionEdgeViewModel.IsEyedropperMode) && Edge.IsEyedropperMode)
+            Shadow.IsShadowEyedropperMode = false;
     }
 
-    private bool SetCallerPropertyReturn<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    private void Shadow_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (!EqualityComparer<T>.Default.Equals(field, value))
-        {
-            field = value;
-            OnPropertyChanged(propertyName ?? string.Empty);
-            return true;
-        }
-
-        return false;
+        if (e.PropertyName == nameof(TransitionShadowViewModel.IsShadowEyedropperMode) && Shadow.IsShadowEyedropperMode)
+            Edge.IsEyedropperMode = false;
     }
 }

--- a/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
@@ -8,6 +8,7 @@ using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.BitmapOperations;
 using TgaBuilderLib.Commands;
 using TgaBuilderLib.Transitions;
+using TgaBuilderLib.ViewModel.Transitions;
 using static TgaBuilderLib.Transitions.TransitionHelper;
 
 namespace TgaBuilderLib.ViewModel;
@@ -32,12 +33,29 @@ public class TransitionViewModel : ViewModelBase
         IMediaFactory mediaFactory,
         ITransitionHelper transitionHelper,
         IBitmapOperations bitmapOperations,
-        MainViewModel mainViewModel)
+        MainViewModel mainViewModel,
+        TransitionPresentersViewModel presenters,
+        TransitionAnalysisViewModel analysis,
+        TransitionPivotSmoothViewModel pivotSmooth,
+        TransitionPivotBricksViewModel pivotBricks,
+        TransitionUnderfillingViewModel underfilling,
+        TransitionEdgeViewModel edge,
+        TransitionShadowViewModel shadow,
+        TransitionManualViewModel manual)
     {
         _mediaFactory = mediaFactory;
         _transitionHelper = transitionHelper;
         _bitmapOperations = bitmapOperations;
         _mainViewModel = mainViewModel;
+
+        Presenters = presenters;
+        Analysis = analysis;
+        PivotSmooth = pivotSmooth;
+        PivotBricks = pivotBricks;
+        Underfilling = underfilling;
+        Edge = edge;
+        Shadow = shadow;
+        Manual = manual;
 
         _image1 = _mediaFactory.CreateEmptyBitmap(64, 64, true);
         _image2 = _mediaFactory.CreateEmptyBitmap(64, 64, true);
@@ -55,6 +73,19 @@ public class TransitionViewModel : ViewModelBase
     private readonly ITransitionHelper _transitionHelper;
     private readonly MainViewModel _mainViewModel;
     private readonly IBitmapOperations _bitmapOperations;
+
+    // =====================================================================
+    // Child View Models
+    // =====================================================================
+
+    public TransitionPresentersViewModel Presenters { get; }
+    public TransitionAnalysisViewModel Analysis { get; }
+    public TransitionPivotSmoothViewModel PivotSmooth { get; }
+    public TransitionPivotBricksViewModel PivotBricks { get; }
+    public TransitionUnderfillingViewModel Underfilling { get; }
+    public TransitionEdgeViewModel Edge { get; }
+    public TransitionShadowViewModel Shadow { get; }
+    public TransitionManualViewModel Manual { get; }
 
     private const int TRANSITIONS_BPP = 4;
 

--- a/TgaBuilderWpfUi/App.DI.xaml.cs
+++ b/TgaBuilderWpfUi/App.DI.xaml.cs
@@ -13,6 +13,8 @@ using TgaBuilderLib.UndoRedo;
 using TgaBuilderLib.Utils;
 using TgaBuilderLib.ViewModel;
 using TgaBuilderLib.ViewModel.Elements;
+using TgaBuilderLib.ViewModel.Modifications;
+using TgaBuilderLib.ViewModel.Transitions;
 using TgaBuilderLib.ViewModel.Views;
 using TgaBuilderWpfUi.Services;
 using TgaBuilderWpfUi.View;
@@ -278,17 +280,77 @@ namespace TgaBuilderWpfUi
 
                 presenter: GetBitmapFromFactory(sp, 2 * PANEL_WIDTH_INIT, PANEL_HEIGHT_INIT, true)));
 
+            // Transition child VMs
+            services.AddTransient(sp => new TransitionPresentersViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>()));
+
+            services.AddTransient(sp => new TransitionAnalysisViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionPivotSmoothViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionPivotBricksViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionUnderfillingViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionEdgeViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionShadowViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
+            services.AddTransient(sp => new TransitionManualViewModel(
+                transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
+
             services.AddTransient(sp => new TransitionViewModel(
                 mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 bitmapOperations: sp.GetRequiredService<IBitmapOperations>(),
-                mainViewModel: sp.GetRequiredService<MainViewModel>()));
+                mainViewModel: sp.GetRequiredService<MainViewModel>(),
+                presenters: sp.GetRequiredService<TransitionPresentersViewModel>(),
+                analysis: sp.GetRequiredService<TransitionAnalysisViewModel>(),
+                pivotSmooth: sp.GetRequiredService<TransitionPivotSmoothViewModel>(),
+                pivotBricks: sp.GetRequiredService<TransitionPivotBricksViewModel>(),
+                underfilling: sp.GetRequiredService<TransitionUnderfillingViewModel>(),
+                edge: sp.GetRequiredService<TransitionEdgeViewModel>(),
+                shadow: sp.GetRequiredService<TransitionShadowViewModel>(),
+                manual: sp.GetRequiredService<TransitionManualViewModel>()));
+
+            // Modification child VMs
+            services.AddTransient(sp => new ModificationsPresentersViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>()));
+
+            services.AddTransient(sp => new ModificationsBasicViewModel(
+                modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
+                presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
+
+            services.AddTransient(sp => new ModificationsColorViewModel(
+                modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
+                presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
+
+            services.AddTransient(sp => new ModificationsColorOverlayViewModel(
+                modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
+                presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
 
             services.AddTransient(sp => new ModificationsViewModel(
                 mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
                 bitmapOperations: sp.GetRequiredService<IBitmapOperations>(),
-                mainViewModel: sp.GetRequiredService<MainViewModel>()));
+                mainViewModel: sp.GetRequiredService<MainViewModel>(),
+                presenters: sp.GetRequiredService<ModificationsPresentersViewModel>(),
+                basic: sp.GetRequiredService<ModificationsBasicViewModel>(),
+                color: sp.GetRequiredService<ModificationsColorViewModel>(),
+                colorOverlay: sp.GetRequiredService<ModificationsColorOverlayViewModel>()));
 
             services.AddSingleton(sp => new MainViewModel(
                 getViewCallback: idx => sp.GetServices<IView>().ElementAt((int)idx),

--- a/TgaBuilderWpfUi/App.DI.xaml.cs
+++ b/TgaBuilderWpfUi/App.DI.xaml.cs
@@ -285,30 +285,37 @@ namespace TgaBuilderWpfUi
                 mediaFactory: sp.GetRequiredService<IMediaFactory>()));
 
             services.AddTransient(sp => new TransitionAnalysisViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionPivotSmoothViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionPivotBricksViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionUnderfillingViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionEdgeViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionShadowViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
             services.AddTransient(sp => new TransitionManualViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 transitionHelper: sp.GetRequiredService<ITransitionHelper>(),
                 presenters: sp.GetRequiredService<TransitionPresentersViewModel>()));
 
@@ -331,14 +338,17 @@ namespace TgaBuilderWpfUi
                 mediaFactory: sp.GetRequiredService<IMediaFactory>()));
 
             services.AddTransient(sp => new ModificationsBasicViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
                 presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
 
             services.AddTransient(sp => new ModificationsColorViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
                 presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
 
             services.AddTransient(sp => new ModificationsColorOverlayViewModel(
+                mediaFactory: sp.GetRequiredService<IMediaFactory>(),
                 modificationsHelper: sp.GetRequiredService<IModificationsHelper>(),
                 presenters: sp.GetRequiredService<ModificationsPresentersViewModel>()));
 

--- a/TgaBuilderWpfUi/View/ModificationsWindow.xaml
+++ b/TgaBuilderWpfUi/View/ModificationsWindow.xaml
@@ -233,7 +233,7 @@
                     Header="Basic"
                     IsExpanded="True"
                     HorizontalAlignment="Stretch">
-                    <local:ModificationsWindowBasicUserControl />
+                    <local:ModificationsWindowBasicUserControl DataContext="{Binding BasicVM}" />
                 </Expander>
 
                 <!-- ============================================================= -->
@@ -244,7 +244,7 @@
                     IsExpanded="True"
                     HorizontalAlignment="Stretch"
                     Margin="0,8,0,0">
-                    <local:ModificationsWindowColorUserControl />
+                    <local:ModificationsWindowColorUserControl DataContext="{Binding ColorVM}" />
                 </Expander>
 
                 <!-- ============================================================= -->
@@ -255,7 +255,7 @@
                     IsExpanded="True"
                     HorizontalAlignment="Stretch"
                     Margin="0,8,0,0">
-                    <local:ModificationsWindowColorOverlayUserControl />
+                    <local:ModificationsWindowColorOverlayUserControl DataContext="{Binding ColorOverlayVM}" />
                 </Expander>
 
             </StackPanel>

--- a/TgaBuilderWpfUi/View/ModificationsWindow.xaml.cs
+++ b/TgaBuilderWpfUi/View/ModificationsWindow.xaml.cs
@@ -32,7 +32,7 @@ namespace TgaBuilderWpfUi.View
 
         private void InputImage_MouseMove(object sender, MouseEventArgs e)
         {
-            if (DataContext is ModificationsViewModel vm && vm.IsColorOverlayEyedropperMode)
+            if (DataContext is ModificationsViewModel vm && vm.ColorOverlayVM.IsColorOverlayEyedropperMode)
             {
                 var position = e.GetPosition((Image)sender);
                 vm.MouseOverInputCommand.Execute((X: (int)position.X, Y: (int)position.Y));
@@ -41,21 +41,21 @@ namespace TgaBuilderWpfUi.View
 
         private void InputImage_MouseEnter(object sender, MouseEventArgs e)
         {
-            if (DataContext is ModificationsViewModel vm && vm.IsColorOverlayEyedropperMode)
+            if (DataContext is ModificationsViewModel vm && vm.ColorOverlayVM.IsColorOverlayEyedropperMode)
                 Mouse.OverrideCursor = _eyedropperCursor;
         }
 
         private void InputImage_MouseLeave(object sender, MouseEventArgs e)
         {
-            if (DataContext is ModificationsViewModel vm && vm.IsColorOverlayEyedropperMode)
+            if (DataContext is ModificationsViewModel vm && vm.ColorOverlayVM.IsColorOverlayEyedropperMode)
                 Mouse.OverrideCursor = null;
         }
 
         private void InputImage_MouseDown(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is ModificationsViewModel vm && vm.IsColorOverlayEyedropperMode)
+            if (DataContext is ModificationsViewModel vm && vm.ColorOverlayVM.IsColorOverlayEyedropperMode)
             {
-                vm.IsColorOverlayEyedropperMode = false;
+                vm.ColorOverlayVM.IsColorOverlayEyedropperMode = false;
                 Mouse.OverrideCursor = null;
             }
         }

--- a/TgaBuilderWpfUi/View/ModificationsWindowBasicUserControl.xaml
+++ b/TgaBuilderWpfUi/View/ModificationsWindowBasicUserControl.xaml
@@ -8,8 +8,8 @@
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:ModificationsViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Modifications;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:ModificationsBasicViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/TgaBuilderWpfUi/View/ModificationsWindowColorOverlayUserControl.xaml
+++ b/TgaBuilderWpfUi/View/ModificationsWindowColorOverlayUserControl.xaml
@@ -7,9 +7,9 @@
              xmlns:elements="clr-namespace:TgaBuilderWpfUi.Elements"
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Modifications;assembly=TgaBuilderLib"
              xmlns:converter="clr-namespace:TgaBuilderWpfUi.Converters"
-             d:DataContext="{d:DesignInstance Type=viewmodel:ModificationsViewModel, IsDesignTimeCreatable=False}"
+             d:DataContext="{d:DesignInstance Type=viewmodel:ModificationsColorOverlayViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>

--- a/TgaBuilderWpfUi/View/ModificationsWindowColorUserControl.xaml
+++ b/TgaBuilderWpfUi/View/ModificationsWindowColorUserControl.xaml
@@ -8,8 +8,8 @@
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:ModificationsViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Modifications;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:ModificationsColorViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d"
              xmlns:converter="clr-namespace:TgaBuilderWpfUi.Converters">
     <UserControl.Resources>

--- a/TgaBuilderWpfUi/View/TransitionWindow.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindow.xaml
@@ -390,7 +390,8 @@
 
             <!-- Smooth mode: Hardness / Widening / Shift sliders -->
             <local:TransitionWindowSmoothUserControl
-                Visibility="{Binding IsSmoothMode, Converter={StaticResource BoolToVisibilityConverter}}" />
+                DataContext="{Binding PivotSmooth}"
+                Visibility="{Binding DataContext.IsSmoothMode, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVisibilityConverter}}" />
 
             <!-- Brick mode: scrollable expanders -->
             <ScrollViewer
@@ -423,7 +424,7 @@
                                     Padding="0"/>
                             </StackPanel>
                         </Expander.Header>
-                        <local:TransitionWindowAnalysisUserControl />
+                        <local:TransitionWindowAnalysisUserControl DataContext="{Binding Analysis}" />
                     </Expander>
 
                     <!-- Parameter Section: Pivot Boundaries -->
@@ -432,7 +433,7 @@
                         IsExpanded="True"
                         HorizontalAlignment="Stretch"
                         Margin="0,8,0,0">
-                        <local:TransitionWindowPivotUserControl />
+                        <local:TransitionWindowPivotUserControl DataContext="{Binding PivotBricks}" />
                     </Expander>
 
                     <!-- Parameter Section: Edge Blending -->
@@ -441,7 +442,7 @@
                         IsExpanded="True"
                         HorizontalAlignment="Stretch"
                         Margin="0,8,0,0">
-                        <local:TransitionWindowEdgeUserControl />
+                        <local:TransitionWindowEdgeUserControl DataContext="{Binding Edge}" />
                     </Expander>
 
                     <!-- Parameter Section: Shadow -->
@@ -450,7 +451,7 @@
                         IsExpanded="True"
                         HorizontalAlignment="Stretch"
                         Margin="0,8,0,0">
-                        <local:TransitionWindowShadowUserControl />
+                        <local:TransitionWindowShadowUserControl DataContext="{Binding Shadow}" />
                     </Expander>
 
                     <!-- Parameter Section: Underfilling -->
@@ -459,7 +460,7 @@
                         IsExpanded="True"
                         HorizontalAlignment="Stretch"
                         Margin="0,8,0,0">
-                        <local:TransitionWindowUnderfillingUserControl />
+                        <local:TransitionWindowUnderfillingUserControl DataContext="{Binding Underfilling}" />
                     </Expander>
 
                     <!-- Parameter Section: Manual -->
@@ -468,7 +469,7 @@
                         IsExpanded="True"
                         HorizontalAlignment="Stretch"
                         Margin="0,8,0,0">
-                        <local:TransitionWindowManualUserControl />
+                        <local:TransitionWindowManualUserControl DataContext="{Binding Manual}" />
                     </Expander>
                 </StackPanel>
             </ScrollViewer>

--- a/TgaBuilderWpfUi/View/TransitionWindow.xaml.cs
+++ b/TgaBuilderWpfUi/View/TransitionWindow.xaml.cs
@@ -39,7 +39,7 @@ namespace TgaBuilderWpfUi.View
 
         private void DoEyedropperMouseMove(Image image, MouseEventArgs e, int imageNum)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
             {
                 var position = e.GetPosition(image);
                 vm.MouseOverCommand.Execute((X: (int)position.X, Y: (int)position.Y, imageNum));
@@ -48,44 +48,44 @@ namespace TgaBuilderWpfUi.View
 
         private void Image1_MouseEnter(object sender, MouseEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
                 Mouse.OverrideCursor = EyedropperCursor;
         }
 
         private void Image1_MouseLeave(object sender, MouseEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
                 Mouse.OverrideCursor = null;
         }
 
         private void Image1_MouseDown(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
             {
-                vm.IsEyedropperMode = false;
-                vm.IsShadowEyedropperMode = false;
+                vm.Edge.IsEyedropperMode = false;
+                vm.Shadow.IsShadowEyedropperMode = false;
                 Mouse.OverrideCursor = null;
             }
         }
 
         private void Image2_MouseEnter(object sender, MouseEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
                 Mouse.OverrideCursor = EyedropperCursor;
         }
 
         private void Image2_MouseLeave(object sender, MouseEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
                 Mouse.OverrideCursor = null;
         }
 
         private void Image2_MouseDown(object sender, MouseButtonEventArgs e)
         {
-            if (DataContext is TransitionViewModel vm && (vm.IsEyedropperMode || vm.IsShadowEyedropperMode))
+            if (DataContext is TransitionViewModel vm && (vm.Edge.IsEyedropperMode || vm.Shadow.IsShadowEyedropperMode))
             {
-                vm.IsEyedropperMode = false;
-                vm.IsShadowEyedropperMode = false;
+                vm.Edge.IsEyedropperMode = false;
+                vm.Shadow.IsShadowEyedropperMode = false;
                 Mouse.OverrideCursor = null;
             }
         }
@@ -95,7 +95,7 @@ namespace TgaBuilderWpfUi.View
             if (DataContext is not TransitionViewModel vm)
                 return;
 
-            if (!vm.IsExplicitTileVisibilityDrawMode && !vm.IsExplicitTileVisibilityEraseMode)
+            if (!vm.Manual.IsExplicitTileVisibilityDrawMode && !vm.Manual.IsExplicitTileVisibilityEraseMode)
                 return;
 
             if (vm.RequestLabelIndicatorCommand is ICommand requestLabelIndicatorCommand)
@@ -110,7 +110,7 @@ namespace TgaBuilderWpfUi.View
             if (DataContext is not TransitionViewModel vm)
                 return;
 
-            if (!vm.IsExplicitTileVisibilityDrawMode && !vm.IsExplicitTileVisibilityEraseMode)
+            if (!vm.Manual.IsExplicitTileVisibilityDrawMode && !vm.Manual.IsExplicitTileVisibilityEraseMode)
                 return;
 
             vm.IsIndicatorMapVisible = true;
@@ -121,7 +121,7 @@ namespace TgaBuilderWpfUi.View
             if (DataContext is not TransitionViewModel vm)
                 return;
 
-            if (!vm.IsExplicitTileVisibilityDrawMode && !vm.IsExplicitTileVisibilityEraseMode)
+            if (!vm.Manual.IsExplicitTileVisibilityDrawMode && !vm.Manual.IsExplicitTileVisibilityEraseMode)
                 return;
 
             vm.IsIndicatorMapVisible = false;
@@ -132,7 +132,7 @@ namespace TgaBuilderWpfUi.View
             if (DataContext is not TransitionViewModel vm)
                 return;
 
-            if (!vm.IsExplicitTileVisibilityDrawMode && !vm.IsExplicitTileVisibilityEraseMode)
+            if (!vm.Manual.IsExplicitTileVisibilityDrawMode && !vm.Manual.IsExplicitTileVisibilityEraseMode)
                 return;
 
             if (e.LeftButton == MouseButtonState.Pressed && vm.SetExplicitTileVisibilityCommand is ICommand setExplicitTileVisibilityCommand)

--- a/TgaBuilderWpfUi/View/TransitionWindowAnalysisUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowAnalysisUserControl.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowAnalysisUserControl"
+﻿<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowAnalysisUserControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -8,8 +8,8 @@
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionAnalysisViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -39,7 +39,7 @@
                                     VerticalAlignment="Center"
                                     Background="Transparent"
                                     BorderThickness="0"
-                                    SelectedIndex="{Binding SelectedSegmentationMethodIndex, UpdateSourceTrigger=PropertyChanged}">
+                                    SelectedIndex="{Binding Analysis.SelectedSegmentationMethodIndex, UpdateSourceTrigger=PropertyChanged}">
                                     <ComboBoxItem Content="Felzenszwalb" />
                                     <ComboBoxItem Content="SLIC" />
                                     <ComboBoxItem Content="Quickshift" />
@@ -56,9 +56,9 @@
                                 <elements:ToggleButtonEx
                                     Width="36"
                                     Height="36"
-                                    Visibility="{Binding ShowGrayBasedSegmentationInputs, Converter={StaticResource BoolToVisibilityConverter}}"
+                                    Visibility="{Binding Analysis.ShowGrayBasedSegmentationInputs, Converter={StaticResource BoolToVisibilityConverter}}"
                                     Icon="{ui:SymbolIcon Table24}"
-                                    IsChecked="{Binding InvertGrayscale}"
+                                    IsChecked="{Binding Analysis.InvertGrayscale}"
                                     ap:MouseOverInfoAP.InfoText="Invert Grayscale: Recommended for textures in which the joints are brighter than the tiles (e.g. sand, snow in the joints)" />
                                  <Path
                                     VerticalAlignment="Center"
@@ -75,7 +75,7 @@
                                     Background="Transparent"
                                     Height="36"
                                     BorderThickness="0"
-                                    SelectedIndex="{Binding SelectedFilterIndex, UpdateSourceTrigger=PropertyChanged}">
+                                    SelectedIndex="{Binding Analysis.SelectedFilterIndex, UpdateSourceTrigger=PropertyChanged}">
                                     <ComboBoxItem Content="None" />
                                     <ComboBoxItem Content="Box Blur" />
                                     <ComboBoxItem Content="Median" />
@@ -86,7 +86,7 @@
 
                             <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowBilateralSigma, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowBilateralSigma, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="Bilateral sigma: color similarity weighting strength">
                                 <TextBlock
                                     VerticalAlignment="Center"
@@ -113,12 +113,12 @@
                                     Maximum="100"
                                     Minimum="0.1"
                                     SmallChange="0.1"
-                                    Value="{Binding BilateralSigma}" />
+                                    Value="{Binding Analysis.BilateralSigma}" />
                             </DockPanel>
 
                             <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowGaussianSigma, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowGaussianSigma, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="Bilateral sigma: color similarity weighting strength">
             <TextBlock
                                     VerticalAlignment="Center"
@@ -145,12 +145,12 @@
                                     Maximum="20"
                                     Minimum="0.1"
                                     SmallChange="0.1"
-                                    Value="{Binding GaussianSigma}" />
+                                    Value="{Binding Analysis.GaussianSigma}" />
                             </DockPanel>
 
                             <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowWatershedBasedSegmentationInputs, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowWatershedBasedSegmentationInputs, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="Marker Count: count of the seed markers for segmentation (1 - 255)">
             <TextBlock
                                     VerticalAlignment="Center"
@@ -180,12 +180,12 @@
                                     Maximum="255"
                                     Minimum="1"
                                     SmallChange="1"
-                                    Value="{Binding MarkerCount}" />
+                                    Value="{Binding Analysis.MarkerCount}" />
                             </DockPanel>
 
                             <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowGridFittingSegmentationInputs, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowGridFittingSegmentationInputs, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="Marker Radius: size of the seed markers for segmentation (1 = small, 20 = large)">
                                 <Path
                                     VerticalAlignment="Center"
@@ -215,13 +215,13 @@
                                     Maximum="20"
                                     Minimum="1"
                                     SmallChange="1"
-                                    Value="{Binding MarkerRadius}" />
+                                    Value="{Binding Analysis.MarkerRadius}" />
                             </DockPanel>
 
         <!-- Hue -->
         <DockPanel
                             Margin="0,8,8,0"
-            Visibility="{Binding ShowGridFittingSegmentationInputs, Converter={StaticResource BoolToVisibilityConverter}}"
+            Visibility="{Binding Analysis.ShowGridFittingSegmentationInputs, Converter={StaticResource BoolToVisibilityConverter}}"
                             ap:MouseOverInfoAP.InfoText="Grid Fit Angle: angle for fitting segmentations (0° = horizontal, 90° = vertical)">
             <Path
                                 VerticalAlignment="Center"
@@ -249,12 +249,12 @@
                                 Maximum="90"
                                 Minimum="-90"
                                 SmallChange="1"
-                                Value="{Binding GridFitAngle}" />
+                                Value="{Binding Analysis.GridFitAngle}" />
         </DockPanel>
 
         <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowFelzenszwalbParameters, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowFelzenszwalbParameters, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="Felzenszwalb min size: minimum component size before region merging">
                                 <Path
                                     VerticalAlignment="Center"
@@ -284,12 +284,12 @@
                                     Maximum="500"
                                     Minimum="1"
                                     SmallChange="1"
-                                    Value="{Binding FelzenszwalbMinSize}" />
+                                    Value="{Binding Analysis.FelzenszwalbMinSize}" />
                             </DockPanel>
 
                             <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowFelzenszwalbParameters, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowFelzenszwalbParameters, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="Felzenszwalb scale: merge tolerance scale factor">
                                 <Path
                                     VerticalAlignment="Center"
@@ -317,12 +317,12 @@
                                     Maximum="500"
                                     Minimum="1"
                                     SmallChange="1"
-                                    Value="{Binding FelzenszwalbScale}" />
+                                    Value="{Binding Analysis.FelzenszwalbScale}" />
                             </DockPanel>
 
                             <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowSlicParameters, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowSlicParameters, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="SLIC segment count: target number of superpixels">
                                 <Path
                                     VerticalAlignment="Center"
@@ -352,12 +352,12 @@
                                     Maximum="2000"
                                     Minimum="1"
                                     SmallChange="1"
-                                    Value="{Binding SlicSegmentCount}" />
+                                    Value="{Binding Analysis.SlicSegmentCount}" />
                             </DockPanel>
 
                             <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowSlicParameters, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowSlicParameters, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="SLIC compactness: trade-off between color similarity and spatial regularity">
                                 <Path
                                     VerticalAlignment="Center"
@@ -385,12 +385,12 @@
                                     Maximum="50"
                                     Minimum="0.1"
                                     SmallChange="0.1"
-                                    Value="{Binding SlicCompactness}" />
+                                    Value="{Binding Analysis.SlicCompactness}" />
                             </DockPanel>
 
                             <DockPanel
                                 Margin="0,8,8,0"
-                                Visibility="{Binding ShowQuickshiftParameters, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowQuickshiftParameters, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="Quickshift max distance: maximum local growth distance from seed">
                                 <Path
                                     VerticalAlignment="Center"
@@ -420,12 +420,12 @@
                                     Maximum="50"
                                     Minimum="1"
                                     SmallChange="1"
-                                    Value="{Binding QuickshiftMaxDist}" />
+                                    Value="{Binding Analysis.QuickshiftMaxDist}" />
                             </DockPanel>
 
                             <DockPanel
                                 Margin="0,3,8,0"
-                                Visibility="{Binding ShowQuickshiftParameters, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Visibility="{Binding Analysis.ShowQuickshiftParameters, Converter={StaticResource BoolToVisibilityConverter}}"
                                 ap:MouseOverInfoAP.InfoText="Quickshift ratio: color similarity threshold scaling">
             <TextBlock
                                     VerticalAlignment="Center"
@@ -450,7 +450,7 @@
                                     Maximum="5"
                                     Minimum="0.1"
                                     SmallChange="0.1"
-                                    Value="{Binding QuickshiftRatio}" />
+                                    Value="{Binding Analysis.QuickshiftRatio}" />
                             </DockPanel>
                         </StackPanel>
                     

--- a/TgaBuilderWpfUi/View/TransitionWindowEdgeUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowEdgeUserControl.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowEdgeUserControl"
+﻿<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowEdgeUserControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -8,8 +8,8 @@
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionEdgeViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d"
              xmlns:converter="clr-namespace:TgaBuilderWpfUi.Converters">
     <UserControl.Resources>
@@ -32,13 +32,13 @@
                                     Width="36"
                                     Height="36"
                                     Margin="0,0,5,0"
-                                    IsChecked="{Binding IsEyedropperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    IsChecked="{Binding Edge.IsEyedropperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     ap:MouseOverInfoAP.InfoText="Pick edge color from image" />
                                 <cp:PortableColorPicker
                                     Width="34"
                                     Height="30"
                                     Margin="4,0,0,0"
-                                    SelectedColor="{Binding EdgeColor, Converter={StaticResource ColorStructToMediaColorConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    SelectedColor="{Binding Edge.EdgeColor, Converter={StaticResource ColorStructToMediaColorConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     ap:MouseOverInfoAP.InfoText="Choose edge color used for edge blending" />
                             </StackPanel>
 
@@ -57,8 +57,8 @@
                                     VerticalAlignment="Center"
                                     BorderThickness="0"
                                     Background="Transparent"
-                                    ItemsSource="{Binding EdgeBlendModes}"
-                                    SelectedItem="{Binding BlendMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                                    ItemsSource="{Binding Edge.EdgeBlendModes}"
+                                    SelectedItem="{Binding Edge.BlendMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <TextBlock
@@ -93,7 +93,7 @@
                                     Maximum="12"
                                     Minimum="0"
                                     SmallChange="1"
-                                    Value="{Binding EdgeWidth}" />
+                                    Value="{Binding Edge.EdgeWidth}" />
                             </DockPanel>
                         </StackPanel>
                     

--- a/TgaBuilderWpfUi/View/TransitionWindowManualUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowManualUserControl.xaml
@@ -9,8 +9,8 @@
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionManualViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -47,7 +47,7 @@
                                     Margin="8,0,0,0"
                                     Icon="{ui:SymbolIcon Backspace24}"
                                     ap:MouseOverInfoAP.InfoText="Reset Explicit Visibility"
-                                    Command="{Binding ResetExplicitVisibilityCommand}" />
+                                    Command="{Binding DataContext.ResetExplicitVisibilityCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
 
 
         </StackPanel>

--- a/TgaBuilderWpfUi/View/TransitionWindowPivotUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowPivotUserControl.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowPivotUserControl"
+﻿<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowPivotUserControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -8,8 +8,8 @@
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionPivotBricksViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -31,7 +31,7 @@
                                     Icon="{ui:SymbolIcon FlipHorizontal24}"
                                     MinHeight="36"
                                     MinWidth="36"
-                                    IsChecked="{Binding ReversePivot}" />
+                                    IsChecked="{Binding PivotBricks.ReversePivot}" />
                                 <elements:ToggleButtonEx
                                     Margin="8,0,0,0"
                                     x:Name="ProtectEdgesToggleButton"
@@ -40,7 +40,7 @@
                                     MinWidth="36"
                                     Icon="{ui:SymbolIcon Shield24}"
                                     ap:MouseOverInfoAP.InfoText="Protect Edges: Enabling ensures that tile texture bordering edges contains tiles and background bordering edges do not contain tiles."
-                                    IsChecked="{Binding ProtectEdges}" />
+                                    IsChecked="{Binding PivotBricks.ProtectEdges}" />
                                 <elements:ToggleButtonEx
                                     VerticalAlignment="Center"
                                     MinHeight="36"
@@ -49,7 +49,7 @@
                                     Icon="{ui:SymbolIcon Cut24}"
                                     ap:MouseOverInfoAP.InfoText="Slice Corners: enable/disable slicing of corner tiles"
                                     IsEnabled="{Binding IsChecked, ElementName=ProtectEdgesToggleButton}"
-                                    IsChecked="{Binding SliceCornerTiles}" />
+                                    IsChecked="{Binding PivotBricks.SliceCornerTiles}" />
                             </StackPanel>
 
                             <DockPanel
@@ -109,7 +109,7 @@
                                     Maximum="1"
                                     Minimum="0"
                                     SmallChange="0.01"
-                                    Value="{Binding WideningValue}" />
+                                    Value="{Binding PivotBricks.WideningValue}" />
                             </DockPanel>
 
                             <DockPanel
@@ -170,7 +170,7 @@
                                     Maximum="1"
                                     Minimum="-1"
                                     SmallChange="0.01"
-                                    Value="{Binding ShiftValue}" />
+                                    Value="{Binding PivotBricks.ShiftValue}" />
                             </DockPanel>
                         </StackPanel>
                     

--- a/TgaBuilderWpfUi/View/TransitionWindowShadowUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowShadowUserControl.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowShadowUserControl"
+﻿<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowShadowUserControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,8 +7,8 @@
              xmlns:elements="clr-namespace:TgaBuilderWpfUi.Elements"
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionShadowViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d"
              xmlns:converter="clr-namespace:TgaBuilderWpfUi.Converters">
     <UserControl.Resources>
@@ -31,13 +31,13 @@
                 Width="36"
                 Height="36"
                 Margin="0,0,5,0"
-                IsChecked="{Binding IsShadowEyedropperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                IsChecked="{Binding Shadow.IsShadowEyedropperMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 ap:MouseOverInfoAP.InfoText="Pick shadow color from image" />
             <cp:PortableColorPicker
                 Width="34"
                 Height="30"
                 Margin="4,0,0,0"
-                SelectedColor="{Binding ShadowColor, Converter={StaticResource ColorStructToMediaColorConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                SelectedColor="{Binding Shadow.ShadowColor, Converter={StaticResource ColorStructToMediaColorConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 ap:MouseOverInfoAP.InfoText="Choose shadow color drawn over background behind tile borders" />
         </StackPanel>
 
@@ -65,7 +65,7 @@
                 Maximum="32"
                 Minimum="0"
                 SmallChange="1"
-                Value="{Binding ShadowSize}" />
+                Value="{Binding Shadow.ShadowSize}" />
         </DockPanel>
 
         <DockPanel
@@ -92,7 +92,7 @@
                 Maximum="100"
                 Minimum="0"
                 SmallChange="1"
-                Value="{Binding ShadowHardness}" />
+                Value="{Binding Shadow.ShadowHardness}" />
         </DockPanel>
     </StackPanel>
 </UserControl>

--- a/TgaBuilderWpfUi/View/TransitionWindowSmoothUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowSmoothUserControl.xaml
@@ -1,12 +1,12 @@
-<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowSmoothUserControl"
+﻿<UserControl x:Class="TgaBuilderWpfUi.View.TransitionWindowSmoothUserControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:elements="clr-namespace:TgaBuilderWpfUi.Elements"
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionPivotSmoothViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -16,8 +16,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
             <StackPanel
-                Margin="0,8,15,0"
-                Visibility="{Binding IsSmoothMode, Converter={StaticResource BoolToVisibilityConverter}}">
+                Margin="0,8,15,0">
 
                 <!-- Hardness Slider -->
                 <DockPanel
@@ -51,7 +50,7 @@
                         Maximum="1"
                         Minimum="0"
                         SmallChange="0.01"
-                        Value="{Binding BlendHardnessValue}" />
+                        Value="{Binding PivotSmooth.BlendHardnessValue}" />
                 </DockPanel>
 
                 <!-- Widening Slider -->
@@ -113,7 +112,7 @@
                         Maximum="1"
                         Minimum="0"
                         SmallChange="0.01"
-                        Value="{Binding WideningValue}" />
+                        Value="{Binding PivotSmooth.WideningValue}" />
                 </DockPanel>
 
                 <!-- Shift Slider -->
@@ -175,7 +174,7 @@
                         Maximum="1"
                         Minimum="-1"
                         SmallChange="0.01"
-                        Value="{Binding ShiftValue}" />
+                        Value="{Binding PivotSmooth.ShiftValue}" />
                 </DockPanel>
             </StackPanel>
 </UserControl>

--- a/TgaBuilderWpfUi/View/TransitionWindowUnderfillingUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowUnderfillingUserControl.xaml
@@ -8,8 +8,8 @@
              xmlns:ap="clr-namespace:TgaBuilderWpfUi.AttachedProperties"
              xmlns:cp="clr-namespace:ColorPicker;assembly=ColorPicker"
              xmlns:enums="clr-namespace:TgaBuilderLib.Enums;assembly=TgaBuilderLib"
-             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel;assembly=TgaBuilderLib"
-             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionViewModel, IsDesignTimeCreatable=False}"
+             xmlns:viewmodel="clr-namespace:TgaBuilderLib.ViewModel.Transitions;assembly=TgaBuilderLib"
+             d:DataContext="{d:DesignInstance Type=viewmodel:TransitionUnderfillingViewModel, IsDesignTimeCreatable=False}"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -30,7 +30,7 @@
                                     Icon="{ui:SymbolIcon CameraSwitch24}"
                                     MinHeight="36"
                                     MinWidth="36"
-                                    IsChecked="{Binding ReverseUnderfilling}" />
+                                    IsChecked="{Binding Underfilling.ReverseUnderfilling}" />
         </StackPanel>
 
         <!-- Underfilling Threshold Slider -->
@@ -52,7 +52,7 @@
                         Maximum="255"
                         Minimum="0"
                         SmallChange="1"
-                        Value="{Binding UnderfillingThreshold}" />
+                        Value="{Binding Underfilling.UnderfillingThreshold}" />
         </DockPanel>
 
         <!-- Pivot slider -->
@@ -116,7 +116,7 @@
                     Minimum="0"
                     SmallChange="0.01"
                     ap:MouseOverInfoAP.InfoText="Underfilling pivot: sets the position of the underfilling area (0 = left, 1 = right)"
-                    Value="{Binding UnderfillingPivot}" />
+                    Value="{Binding Underfilling.UnderfillingPivot}" />
         </DockPanel>
 
 


### PR DESCRIPTION
Modularize the ViewModels for Transition and Modification so that we avoid large, monolithic view models. We do this by giving each expander section its own view model. Each is derived from a special view model base called `ThrottledViewModelBase` which has methods to deal with a large number of Property Changed events, throttles them, so that not every event is triggering the expensive recalculation.

## Child View Models

### Transitions (`TgaBuilderLib/ViewModel/Transitions/`)

- **TransitionPresentersViewModel** — shared bitmap state (Image1, Image2, ResultImage, LabelMap, IndicatorMap, pixel buffers, IsSmoothMode)
- **TransitionAnalysisViewModel** — segmentation method, filter, and analysis parameters; `DoPreProcessing` sets `RequiresAnalysis`
- **TransitionPivotSmoothViewModel** — smooth pivot/blend controls
- **TransitionPivotBricksViewModel** — brick pivot/selection controls; `DoPreProcessing` sets `RequiresSelectionBuilding`
- **TransitionUnderfillingViewModel** — underfilling parameters; `DoPreProcessing` sets `RequiresSelectionBuilding`
- **TransitionEdgeViewModel** — edge color/blend mode; `DoPreProcessing` sets `RequiresDrawing`
- **TransitionShadowViewModel** — shadow parameters; `DoPreProcessing` sets `RequiresDrawing`
- **TransitionManualViewModel** — draw/erase mode; `DoPreProcessing` sets `RequiresSelectionBuilding`

### Modifications (`TgaBuilderLib/ViewModel/Modifications/`)

- **ModificationsPresentersViewModel** — shared bitmap state (InputImage, ResultImage, pixel buffer)
- **ModificationsBasicViewModel** — exposure, brightness, contrast, highlights, shadows, whites, blacks
- **ModificationsColorViewModel** — saturation, vibrance, hue, temperature, tint
- **ModificationsColorOverlayViewModel** — overlay color, amount, mix mode, mode-specific parameters

## Self-Sufficient Recalculation

Each child VM implements `Recalculate()` to run the full pipeline independently — reading pixel buffers from `PresentersViewModel`, calling the helper's mix/apply methods, creating the result bitmap, and writing back to `Presenters.ResultImage`. Children receive `IMediaFactory` via constructor injection for bitmap creation. `ThrottledViewModelBase` exposes a public `RequestRecalculation()` method for external triggers.

## View DataContext Wiring

All child user controls in both Avalonia and WPF receive their child VM as `DataContext`:
- Avalonia: `DataContext="{Binding Analysis}"`, updated `x:DataType` to child VM types
- WPF: `DataContext="{Binding Analysis}"`, updated `d:DataContext` design-time instances

## Slimmed Parent ViewModels

- `TransitionViewModel` — removed all brick/smooth-specific properties (analysis params, edge, shadow, underfilling, manual, blend hardness); parent reads from children's public properties only when configuring the helper for the Mix command
- `ModificationsViewModel` — removed all basic/color/overlay properties and the recalculation pipeline; delegates image state through `Presenters`

## Wiring

- All children inherit from `ThrottledViewModelBase` and hold a reference to their respective `PresentersViewModel`
- `TransitionViewModel` and `ModificationsViewModel` expose children as public properties
- DI is wired in both WPF (`App.DI.xaml.cs`) and Avalonia (`App.DI.axaml.cs`) with updated constructor parameters
- Added `CleanUp()` method to `IModificationsHelper`/`ModificationsHelper`, similar to `TransitionHelper.CleanUp()`