### PR TITLE
Add support to write Krita .kra files

### DIFF
--- a/TgaBuilderAvaloniaUi/App.DI.axaml.cs
+++ b/TgaBuilderAvaloniaUi/App.DI.axaml.cs
@@ -20,6 +20,7 @@ using TgaBuilderLib.ViewModel.Elements;
 using TgaBuilderLib.ViewModel.Views;
 using Avalonia;
 using Avalonia.Controls;
+using TgaBuilderLib.Krita;
 
 namespace TgaBuilderAvaloniaUi
 {
@@ -81,6 +82,7 @@ namespace TgaBuilderAvaloniaUi
 
         private void AddCoreServicesToProvider(IServiceCollection services)
         {
+            services.AddSingleton<IKraFileService, KraFileService>();
             services.AddSingleton<ITrngDecrypter, TrngDecrypter>();
             services.AddSingleton<IBitmapBytesIO, BitmapBytesIO>();
 

--- a/TgaBuilderAvaloniaUi/Services/FileService.cs
+++ b/TgaBuilderAvaloniaUi/Services/FileService.cs
@@ -147,7 +147,8 @@ namespace TgaBuilderAvaloniaUi.Services
             var fileTypeChoices = new List<FilePickerFileType>
                 {
                     new("Png Files (*.png)") { Patterns = new[] { "*.png" }},
-                    new("Tga Files (*.tga)") { Patterns = new[] { "*.tga" }}
+                    new("Tga Files (*.tga)") { Patterns = new[] { "*.tga" }},
+                    new("Krita Files (*.kra)") { Patterns = new[] { "*.kra" }}
                 };
 
             var fileResult = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions

--- a/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.FromKrita.cs
+++ b/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.FromKrita.cs
@@ -18,13 +18,6 @@ public partial class BitmapBytesIO
 
         IReadableBitmap sourceBitmap;
 
-        byte[] LoadedPngData;
-
-        // 1. Generate a unique temporary file path in the application directory
-        string appDirectory = AppDomain.CurrentDomain.BaseDirectory;
-        string tempFileName = $"temp_merged_{Guid.NewGuid()}.png";
-        string tempFilePath = Path.Combine(appDirectory, tempFileName);
-
         // 2. Open the .kra file as a ZIP archive
         using (ZipArchive archive = ZipFile.OpenRead(kraFilePath))
         {
@@ -38,7 +31,7 @@ public partial class BitmapBytesIO
             // 4. Extract the file to a byte array
             using var entryStream = mergedImageEntry.Open();
             using var ms = new MemoryStream();
-            
+
             entryStream.CopyTo(ms);
 
             ms.Position = 0;

--- a/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.ToKrita.cs
+++ b/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.ToKrita.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using TgaBuilderLib.Abstraction;
+﻿using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.Krita;
 
 namespace TgaBuilderLib.BitmapBytesIO;
@@ -13,19 +8,16 @@ public partial class BitmapBytesIO
 
     public void ToKrita(IReadableBitmap bitmap)
     {
-        if (!bitmap.HasAlpha)
-        {
-            bitmap = GetBgra32fromRgb24(_mediaFactory.CloneBitmap(bitmap));
-        }
-
-        _lastHadAlpha = bitmap.HasAlpha;
+        LoadedHasAlpha = bitmap.HasAlpha;
 
         LoadedWidth = bitmap.PixelWidth;
         LoadedHeight = bitmap.PixelHeight;
 
-        ActualDataLength = LoadedWidth * LoadedHeight * 4;
+        int bpp = LoadedHasAlpha ? 4 : 3;
+
+        ActualDataLength = LoadedWidth * LoadedHeight * bpp;
         LoadedBytes = _bytesPool.Rent(ActualDataLength);
-        bitmap.CopyPixels(LoadedBytes, LoadedWidth * 4, 0);
+        bitmap.CopyPixels(LoadedBytes, LoadedWidth * bpp, 0);
     }
 
     public void WriteKrita(string filePath, CancellationToken? cancellationToken = null)
@@ -37,76 +29,16 @@ public partial class BitmapBytesIO
 
         _kritaFileService.OutputPath = filePath;
 
-        var layerSource = new LayerSource(LoadedBytes, LoadedWidth, LoadedHeight, _kritaFileService.KraMainDoc.ImageName);
+        var layerSource = new LayerSource(bgra: LoadedBytes,
+                                          width: LoadedWidth,
+                                          height: LoadedHeight,
+                                          hasAlpha: LoadedHasAlpha,
+                                          name: _kritaFileService.KraMainDoc.ImageName);
 
         _kritaFileService.LayerSources.Add(layerSource);
 
         _kritaFileService.WriteFile();
 
         _kritaFileService.CleanUp();
-    }
-
-    private IWriteableBitmap GetBgra32fromRgb24(IWriteableBitmap rgb24Bmmp)
-    {
-        if (rgb24Bmmp == null)
-            throw new ArgumentNullException(nameof(rgb24Bmmp), "Source bitmap cannot be null.");
-
-        if (rgb24Bmmp.HasAlpha)
-            throw new ArgumentException("Source bitmap must be in RGB24 format.", nameof(rgb24Bmmp));
-
-        // Create a new IWriteableBitmap with BGRA32 format
-        var targetBitmap = _mediaFactory.CreateEmptyBitmap(
-            width: rgb24Bmmp.PixelWidth,
-            height: rgb24Bmmp.PixelHeight,
-            hasAlpha: true);
-
-        var targetDirtyRect = new PixelRect(0, 0, targetBitmap.PixelWidth, targetBitmap.PixelHeight);
-
-        // Lock the source and target bitmaps for writing
-
-        using (var sourceLocker = rgb24Bmmp.GetLocker())
-        using (var targetLocker = targetBitmap.GetLocker(targetDirtyRect))
-        {
-            unsafe
-            {
-                byte* srcPtr = (byte*)sourceLocker.BackBuffer;
-                byte* dstPtr = (byte*)targetLocker.BackBuffer;
-
-                int width = rgb24Bmmp.PixelWidth;
-                int height = rgb24Bmmp.PixelHeight;
-                int srcStride = rgb24Bmmp.BackBufferStride;
-                int dstStride = targetBitmap.BackBufferStride;
-
-                int dstIdx = 0, srcIdx = 0;
-
-                byte r, g, b;
-
-                for (int y = 0; y < height; y++)
-                {
-                    for (int x = 0; x < width; x++)
-                    {
-                        srcIdx = (y * srcStride) + (x * 3);
-
-                        // Read RGB values from the source bitmap
-                        r = srcPtr[srcIdx];
-                        g = srcPtr[srcIdx + 1];
-                        b = srcPtr[srcIdx + 2];
-
-                        dstIdx = (y * dstStride) + (x * 4);
-
-                        if ((r, g, b) != (255, 0, 255)) // Write BGRA values to the target bitmap if not magenta
-                        {
-                            dstPtr[dstIdx] = b;   // B
-                            dstPtr[dstIdx + 1] = g;   // G
-                            dstPtr[dstIdx + 2] = r;   // R
-                            dstPtr[dstIdx + 3] = 255; // A (fully opaque)
-                        }
-                    }
-                }
-            }
-        }
-
-
-        return targetBitmap;
     }
 }

--- a/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.ToKrita.cs
+++ b/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.ToKrita.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.Krita;
+
+namespace TgaBuilderLib.BitmapBytesIO;
+
+public partial class BitmapBytesIO
+{
+
+    public void ToKrita(IReadableBitmap bitmap)
+    {
+        if (!bitmap.HasAlpha)
+        {
+            bitmap = GetBgra32fromRgb24(_mediaFactory.CloneBitmap(bitmap));
+        }
+
+        _lastHadAlpha = bitmap.HasAlpha;
+
+        LoadedWidth = bitmap.PixelWidth;
+        LoadedHeight = bitmap.PixelHeight;
+
+        ActualDataLength = LoadedWidth * LoadedHeight * 4;
+        LoadedBytes = _bytesPool.Rent(ActualDataLength);
+        bitmap.CopyPixels(LoadedBytes, LoadedWidth * 4, 0);
+    }
+
+    public void WriteKrita(string filePath, CancellationToken? cancellationToken = null)
+    {
+        if (LoadedBytes is null)
+            throw new ArgumentNullException($"{nameof(LoadedBytes)} is null.");
+
+        _kritaFileService.KraMainDoc.ImageName = Path.GetFileName(filePath);
+
+        _kritaFileService.OutputPath = filePath;
+
+        var layerSource = new LayerSource(LoadedBytes, LoadedWidth, LoadedHeight, _kritaFileService.KraMainDoc.ImageName);
+
+        _kritaFileService.LayerSources.Add(layerSource);
+
+        _kritaFileService.WriteFile();
+
+        _kritaFileService.CleanUp();
+    }
+
+    private IWriteableBitmap GetBgra32fromRgb24(IWriteableBitmap rgb24Bmmp)
+    {
+        if (rgb24Bmmp == null)
+            throw new ArgumentNullException(nameof(rgb24Bmmp), "Source bitmap cannot be null.");
+
+        if (rgb24Bmmp.HasAlpha)
+            throw new ArgumentException("Source bitmap must be in RGB24 format.", nameof(rgb24Bmmp));
+
+        // Create a new IWriteableBitmap with BGRA32 format
+        var targetBitmap = _mediaFactory.CreateEmptyBitmap(
+            width: rgb24Bmmp.PixelWidth,
+            height: rgb24Bmmp.PixelHeight,
+            hasAlpha: true);
+
+        var targetDirtyRect = new PixelRect(0, 0, targetBitmap.PixelWidth, targetBitmap.PixelHeight);
+
+        // Lock the source and target bitmaps for writing
+
+        using (var sourceLocker = rgb24Bmmp.GetLocker())
+        using (var targetLocker = targetBitmap.GetLocker(targetDirtyRect))
+        {
+            unsafe
+            {
+                byte* srcPtr = (byte*)sourceLocker.BackBuffer;
+                byte* dstPtr = (byte*)targetLocker.BackBuffer;
+
+                int width = rgb24Bmmp.PixelWidth;
+                int height = rgb24Bmmp.PixelHeight;
+                int srcStride = rgb24Bmmp.BackBufferStride;
+                int dstStride = targetBitmap.BackBufferStride;
+
+                int dstIdx = 0, srcIdx = 0;
+
+                byte r, g, b;
+
+                for (int y = 0; y < height; y++)
+                {
+                    for (int x = 0; x < width; x++)
+                    {
+                        srcIdx = (y * srcStride) + (x * 3);
+
+                        // Read RGB values from the source bitmap
+                        r = srcPtr[srcIdx];
+                        g = srcPtr[srcIdx + 1];
+                        b = srcPtr[srcIdx + 2];
+
+                        dstIdx = (y * dstStride) + (x * 4);
+
+                        if ((r, g, b) != (255, 0, 255)) // Write BGRA values to the target bitmap if not magenta
+                        {
+                            dstPtr[dstIdx] = b;   // B
+                            dstPtr[dstIdx + 1] = g;   // G
+                            dstPtr[dstIdx + 2] = r;   // R
+                            dstPtr[dstIdx + 3] = 255; // A (fully opaque)
+                        }
+                    }
+                }
+            }
+        }
+
+
+        return targetBitmap;
+    }
+}

--- a/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.cs
+++ b/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.cs
@@ -2,15 +2,18 @@
 using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.Enums;
 using TgaBuilderLib.FileHandling;
+using TgaBuilderLib.Krita;
 
 namespace TgaBuilderLib.BitmapBytesIO
 {
     public partial class BitmapBytesIO : IBitmapBytesIO
     {
         public BitmapBytesIO(
-            IMediaFactory mediaFactory)
+            IMediaFactory mediaFactory,
+            IKraFileService kraFileService)
         {
             _mediaFactory = mediaFactory ?? throw new ArgumentNullException(nameof(mediaFactory));
+            _kritaFileService = kraFileService ?? throw new ArgumentNullException(nameof(kraFileService));
         }
 
         private const int MAX_SIZE = 32768;
@@ -19,6 +22,8 @@ namespace TgaBuilderLib.BitmapBytesIO
 
         private readonly ArrayPool<byte> _bytesPool = ArrayPool<byte>.Shared;
         private readonly IMediaFactory _mediaFactory;
+
+        private readonly IKraFileService _kritaFileService;
 
         public ResultStatus ResultInfo { get; private set; } = ResultStatus.Success;
 

--- a/TgaBuilderLib/BitmapBytesIO/IBitmapBytesIO.cs
+++ b/TgaBuilderLib/BitmapBytesIO/IBitmapBytesIO.cs
@@ -43,20 +43,19 @@ namespace TgaBuilderLib.BitmapBytesIO
 
         IWriteableBitmap GetLoadedBitmap();
 
-        void ToUsual(
-            IReadableBitmap bitmap,
-            string extension);
+        void ToUsual(IReadableBitmap bitmap, string extension);
 
         void WriteUsual(
             string filePath,
             CancellationToken? cancellationToken = null);
 
-        void ToTga(
-            IReadableBitmap bitmap);
+        void ToTga(IReadableBitmap bitmap);
 
-        void WriteTga(
-            string filePath,
-            CancellationToken? cancellationToken = null);
+        void ToKrita(IReadableBitmap bitmap);
+
+        void WriteKrita(string filePath, CancellationToken? cancellationToken = null);
+
+        void WriteTga(string filePath, CancellationToken? cancellationToken = null);
 
         void ClearLoadedData();
     }

--- a/TgaBuilderLib/FileHandling/ImageFileManager.cs
+++ b/TgaBuilderLib/FileHandling/ImageFileManager.cs
@@ -115,6 +115,9 @@ namespace TgaBuilderLib.FileHandling
             if (IsTga(extension))
                 _bitmapIO.ToTga(bitmap);
 
+            else if (IsKrita(extension))
+                _bitmapIO.ToKrita(bitmap);
+
             else if (IsUsual(extension))
                 _bitmapIO.ToUsual(bitmap, extension);
 
@@ -137,6 +140,9 @@ namespace TgaBuilderLib.FileHandling
 
             else if (IsUsual(extension))
                 _bitmapIO.WriteUsual(fileName, cancellationToken);
+
+            else if (IsKrita(extension))
+                _bitmapIO.WriteKrita(fileName, cancellationToken);
 
             else
                 throw new NotSupportedException($"Unsupported file format: {extension}");
@@ -202,6 +208,9 @@ namespace TgaBuilderLib.FileHandling
 
         private bool IsTga(string extension)
             => extension == "tga";
+
+        private bool IsKrita(string extension)
+            => extension == "kra";
 
         private bool IsUsual(string extension)
             => extension is "png" or "jpg" or "jpeg" or "bmp";

--- a/TgaBuilderLib/Krita/DocumentInfo.cs
+++ b/TgaBuilderLib/Krita/DocumentInfo.cs
@@ -1,0 +1,40 @@
+namespace TgaBuilderLib.Krita;
+
+public class DocumentInfo
+{
+    public string ImageName { get; set; } = "Unnamed";
+    public string Description { get; set; } = string.Empty;
+    public string Subject { get; set; } = string.Empty;
+    public string Abstract { get; set; } = string.Empty;
+    public string Keyword { get; set; } = string.Empty;
+    public string InitialCreator { get; set; } = "TgaBuilder";
+    public int EditingCycles { get; set; } = 1;
+    public int EditingTime { get; set; } = 0;
+    public string CreatorFirstName { get; set; } = string.Empty;
+    public string CreatorLastName { get; set; } = string.Empty;
+    public string Creator { get; set; } = string.Empty;
+    public string AuthorFullName { get; set; } = string.Empty;
+
+
+    public string Build()
+        =>  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<!DOCTYPE document-info PUBLIC '-//KDE//DTD document-info 1.1//EN' 'http://www.calligra.org/DTD/document-info-1.1.dtd'>\n" +
+            "<document-info xmlns=\"http://www.calligra.org/DTD/document-info\">\n" +
+            " <about>\n" +
+            $"  <title>{Xml.Escape(ImageName)}</title>\n" +
+            $"  <description>{Xml.Escape(Description)}</description>\n" +
+            $"  <subject>{Xml.Escape(Subject)}</subject>\n" +
+            $"  <abstract>{Xml.Escape(Abstract)}</abstract>\n" +
+            $"  <keyword>{Xml.Escape(Keyword)}</keyword>\n" +
+            $"  <initial-creator>{Xml.Escape(InitialCreator)}</initial-creator>\n" +
+            $"  <editing-cycles>{EditingCycles}</editing-cycles>\n" +
+            $"  <editing-time>{EditingTime}</editing-time>\n" +
+            $"  <creator-first-name>{Xml.Escape(CreatorFirstName)}</creator-first-name>\n" +
+            $"  <creator-last-name>{Xml.Escape(CreatorLastName)}</creator-last-name>\n" +
+            $"  <creator>{Xml.Escape(Creator)}</creator>\n" +
+            " </about>\n" +
+            " <author>\n" +
+            $"  <full-name>{Xml.Escape(AuthorFullName)}</full-name>\n" +
+            " </author>\n" +
+            "</document-info>\n";
+}

--- a/TgaBuilderLib/Krita/IKraFileService.cs
+++ b/TgaBuilderLib/Krita/IKraFileService.cs
@@ -1,0 +1,15 @@
+﻿using TgaBuilderLib.Abstraction;
+
+namespace TgaBuilderLib.Krita
+{
+    public interface IKraFileService
+    {
+        DocumentInfo KraDocumentInfo { get; set; }
+        MainDoc KraMainDoc { get; set; }
+        List<LayerSource> LayerSources { get; set; }
+        string OutputPath { get; set; }
+
+        void CleanUp();
+        void WriteFile();
+    }
+}

--- a/TgaBuilderLib/Krita/KraFileService.Imaging.cs
+++ b/TgaBuilderLib/Krita/KraFileService.Imaging.cs
@@ -1,13 +1,10 @@
-using System.Runtime.InteropServices;
-using TgaBuilderLib.Abstraction;
-
 namespace TgaBuilderLib.Krita;
 
 public partial class KraFileService
 {
 
 
-    /// <summary>Encodes straight-alpha BGRA8888 pixels to a PNG byte array via Avalonia.</summary>
+    /// <summary>Encodes straight-alpha BGRA8888 pixels to a PNG byte array.</summary>
     public byte[] EncodePng(byte[] bgra, int width, int height)
     {
         var bitmap = _mediaFactory.CreateBitmapFromRaw(width, height, hasAlpha: true, bgra, stride: width * 4);
@@ -18,35 +15,53 @@ public partial class KraFileService
     /// Composites layers (index 0 = bottom) onto a transparent WxH canvas using the
     /// straight-alpha "source over" operator. Smaller layers are placed at the top-left.
     /// </summary>
-    private byte[] Composite(IReadOnlyList<LayerSource> layers, int w, int h)
+    private byte[] Composite(IReadOnlyList<LayerSource> layers, int width, int height)
     {
-        var canvas = new byte[w * h * 4]; // BGRA, fully transparent
+        var canvas = new byte[width * height * 4]; // BGRA, fully transparent
 
-        foreach (var l in layers)
+        foreach (var layer in layers)
         {
-            for (int y = 0; y < l.Height && y < h; y++)
-            {
-                int sRow = y * l.Width * 4;
-                int dRow = y * w * 4;
-                for (int x = 0; x < l.Width && x < w; x++)
-                {
-                    int s = sRow + x * 4;
-                    int d = dRow + x * 4;
+            int layerBpp = layer.HasAlpha ? 4 : 3;
 
-                    float sa = l.Bgra[s + 3] / 255f;
-                    if (sa <= 0f) continue;
-                    float da = canvas[d + 3] / 255f;
-                    float oa = sa + da * (1f - sa);
-                    if (oa <= 0f) continue;
+            for (int y = 0; y < layer.Height && y < height; y++)
+            {
+                int sRow = y * layer.Width * layerBpp;
+                int dRow = y * width * 4;
+                for (int x = 0; x < layer.Width && x < width; x++)
+                {
+                    int sPix = sRow + x * layerBpp;
+                    int dPix = dRow + x * 4;
+
+                    float sourceAlpha = layer.HasAlpha
+                        ? layer.PixelBytes[sPix + 3] / 255f
+                        : 1f;
+
+                    if (sourceAlpha <= 0f)
+                        continue;
+
+                    float destinationAlpha = canvas[dPix + 3] / 255f;
+
+                    float oa = sourceAlpha + destinationAlpha * (1f - sourceAlpha);
+
+                    if (oa <= 0f)
+                        continue;
 
                     for (int c = 0; c < 3; c++)
                     {
-                        float sc = l.Bgra[s + c];
-                        float dc = canvas[d + c];
-                        float oc = (sc * sa + dc * da * (1f - sa)) / oa;
-                        canvas[d + c] = (byte)Math.Clamp(oc + 0.5f, 0f, 255f);
+                        float sc = layer.PixelBytes[sPix + c];
+                        float dc = canvas[dPix + c];
+                        float oc = (sc * sourceAlpha + dc * destinationAlpha * (1f - sourceAlpha)) / oa;
+                        canvas[dPix + c] = (byte)Math.Clamp(oc + 0.5f, 0f, 255f);
                     }
-                    canvas[d + 3] = (byte)Math.Clamp(oa * 255f + 0.5f, 0f, 255f);
+
+                    if (!layer.HasAlpha) // RGA: Swap R and B if no alpha, since source is probably RGB and canvas is BGRA
+                    {
+                        byte temp = canvas[dPix];
+                        canvas[dPix] = canvas[dPix + 2];
+                        canvas[dPix + 2] = temp;
+                    }
+
+                    canvas[dPix + 3] = (byte)Math.Clamp(oa * 255f + 0.5f, 0f, 255f);
                 }
             }
         }

--- a/TgaBuilderLib/Krita/KraFileService.Imaging.cs
+++ b/TgaBuilderLib/Krita/KraFileService.Imaging.cs
@@ -1,0 +1,79 @@
+using System.Runtime.InteropServices;
+using TgaBuilderLib.Abstraction;
+
+namespace TgaBuilderLib.Krita;
+
+public partial class KraFileService
+{
+
+
+    /// <summary>Encodes straight-alpha BGRA8888 pixels to a PNG byte array via Avalonia.</summary>
+    public byte[] EncodePng(byte[] bgra, int width, int height)
+    {
+        var bitmap = _mediaFactory.CreateBitmapFromRaw(width, height, hasAlpha: true, bgra, stride: width * 4);
+        return bitmap.ToMemoryStream().ToArray();
+    }
+
+    /// <summary>
+    /// Composites layers (index 0 = bottom) onto a transparent WxH canvas using the
+    /// straight-alpha "source over" operator. Smaller layers are placed at the top-left.
+    /// </summary>
+    private byte[] Composite(IReadOnlyList<LayerSource> layers, int w, int h)
+    {
+        var canvas = new byte[w * h * 4]; // BGRA, fully transparent
+
+        foreach (var l in layers)
+        {
+            for (int y = 0; y < l.Height && y < h; y++)
+            {
+                int sRow = y * l.Width * 4;
+                int dRow = y * w * 4;
+                for (int x = 0; x < l.Width && x < w; x++)
+                {
+                    int s = sRow + x * 4;
+                    int d = dRow + x * 4;
+
+                    float sa = l.Bgra[s + 3] / 255f;
+                    if (sa <= 0f) continue;
+                    float da = canvas[d + 3] / 255f;
+                    float oa = sa + da * (1f - sa);
+                    if (oa <= 0f) continue;
+
+                    for (int c = 0; c < 3; c++)
+                    {
+                        float sc = l.Bgra[s + c];
+                        float dc = canvas[d + c];
+                        float oc = (sc * sa + dc * da * (1f - sa)) / oa;
+                        canvas[d + c] = (byte)Math.Clamp(oc + 0.5f, 0f, 255f);
+                    }
+                    canvas[d + 3] = (byte)Math.Clamp(oa * 255f + 0.5f, 0f, 255f);
+                }
+            }
+        }
+        return canvas;
+    }
+
+    /// <summary>Nearest-neighbour downscale (BGRA) so the longest side is at most <paramref name="maxSide"/>.</summary>
+    private byte[] Downscale(byte[] bgra, int w, int h, int maxSide, out int outW, out int outH)
+    {
+        if (w <= maxSide && h <= maxSide)
+        {
+            outW = w; outH = h;
+            return bgra;
+        }
+        float scale = maxSide / (float)Math.Max(w, h);
+        outW = Math.Max(1, (int)(w * scale));
+        outH = Math.Max(1, (int)(h * scale));
+        var outBuf = new byte[outW * outH * 4];
+        for (int y = 0; y < outH; y++)
+        {
+            int sy = Math.Min(h - 1, (int)(y / scale));
+            for (int x = 0; x < outW; x++)
+            {
+                int sx = Math.Min(w - 1, (int)(x / scale));
+                Buffer.BlockCopy(bgra, (sy * w + sx) * 4, outBuf, (y * outW + x) * 4, 4);
+            }
+        }
+        return outBuf;
+    }
+}

--- a/TgaBuilderLib/Krita/KraFileService.cs
+++ b/TgaBuilderLib/Krita/KraFileService.cs
@@ -1,0 +1,94 @@
+using TgaBuilderLib.Abstraction;
+using TgaBuilderLib.BitmapOperations;
+
+namespace TgaBuilderLib.Krita
+{
+    public partial class KraFileService
+    {
+        private readonly IMediaFactory _mediaFactory;
+        private readonly IBitmapOperations _bitmapOperations;
+
+        public KraFileService(IMediaFactory mediaFactory, IBitmapOperations bitmapOperations)
+        {
+            _mediaFactory = mediaFactory;
+            _bitmapOperations = bitmapOperations;
+        }
+
+
+        public string OutputPath { get; set; } = "output.kra";
+
+        public MainDoc KraMainDoc { get; set; } = new();
+        public DocumentInfo KraDocumentInfo { get; set; } = new();
+
+        public List<IWriteableBitmap> LayerBitmaps { get; set; } = new();
+
+        public void CleanUp()
+        {
+            KraMainDoc = new();
+            KraDocumentInfo = new();
+            LayerBitmaps.Clear();
+        }
+
+        public void WriteFile()
+        {
+            var dir = Path.GetDirectoryName(OutputPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            // Decode every PNG into straight-alpha BGRA via Avalonia.
+            var layers = new List<LayerSource>();
+            int n = 0;
+            foreach (var layerBitmap in LayerBitmaps)
+            {
+                byte[] bgra = layerBitmap.ToMemoryStream().ToArray();
+                n++;
+                layers.Add(new LayerSource
+                {
+                    Name = $"Layer {n}",
+                    FileName = $"layer{n}",
+                    Bgra = bgra,
+                    Width = layerBitmap.PixelWidth,
+                    Height = layerBitmap.PixelHeight,
+                });
+            }
+
+            if (layers.Count == 0)
+            {
+                throw new InvalidOperationException("No PNG files could be decoded.");
+            }
+
+            int canvasW = layers.Max(l => l.Width);
+            int canvasH = layers.Max(l => l.Height);
+
+            // Optional preview/merged image. Failure here must not abort the .kra itself.
+            byte[]? mergedPng = null;
+            byte[]? previewPng = null;
+
+            byte[] merged = Composite(layers, canvasW, canvasH);
+            mergedPng = EncodePng(merged, canvasW, canvasH);
+
+            byte[] small = Downscale(merged, canvasW, canvasH, 256, out int pw, out int ph);
+            previewPng = EncodePng(small, pw, ph);
+
+            string imageName = SanitizeName(Path.GetFileNameWithoutExtension(OutputPath));
+
+            var kraWriter = new KraWriter();
+
+            kraWriter.Write(outputPath: OutputPath,
+                            imageName: imageName,
+                            canvasW: canvasW,
+                            canvasH: canvasH,
+                            layers: layers,
+                            iccProfile: null,
+                            mergedPng: mergedPng,
+                            previewPng: previewPng);
+
+            static string SanitizeName(string raw)
+            {
+                if (string.IsNullOrWhiteSpace(raw)) return "image";
+                var chars = raw.Select(c => char.IsLetterOrDigit(c) || c is '_' or '-' ? c : '_').ToArray();
+                return new string(chars);
+            }
+        }
+    }
+}

--- a/TgaBuilderLib/Krita/KraFileService.cs
+++ b/TgaBuilderLib/Krita/KraFileService.cs
@@ -35,23 +35,6 @@ namespace TgaBuilderLib.Krita
             if (!string.IsNullOrEmpty(dir))
                 Directory.CreateDirectory(dir);
 
-            // Decode every PNG into straight-alpha BGRA via Avalonia.
-            //var layers = new List<LayerSource>();
-            //int n = 0;
-            //foreach (var layerBitmap in LayerSources)
-            //{
-            //    byte[] bgra = layerBitmap.ToMemoryStream().ToArray();
-            //    n++;
-            //    layers.Add(new LayerSource
-            //    {
-            //        Name = $"Layer {n}",
-            //        FileName = $"layer{n}",
-            //        Bgra = bgra,
-            //        Width = layerBitmap.PixelWidth,
-            //        Height = layerBitmap.PixelHeight,
-            //    });
-            //}
-
             if (LayerSources.Count == 0)
             {
                 throw new InvalidOperationException("No PNG files could be decoded.");
@@ -60,7 +43,6 @@ namespace TgaBuilderLib.Krita
             int canvasW = LayerSources.Max(l => l.Width);
             int canvasH = LayerSources.Max(l => l.Height);
 
-            // Optional preview/merged image. Failure here must not abort the .kra itself.
             byte[]? mergedPng = null;
             byte[]? previewPng = null;
 

--- a/TgaBuilderLib/Krita/KraFileService.cs
+++ b/TgaBuilderLib/Krita/KraFileService.cs
@@ -3,7 +3,7 @@ using TgaBuilderLib.BitmapOperations;
 
 namespace TgaBuilderLib.Krita
 {
-    public partial class KraFileService
+    public partial class KraFileService : IKraFileService
     {
         private readonly IMediaFactory _mediaFactory;
         private readonly IBitmapOperations _bitmapOperations;
@@ -20,13 +20,13 @@ namespace TgaBuilderLib.Krita
         public MainDoc KraMainDoc { get; set; } = new();
         public DocumentInfo KraDocumentInfo { get; set; } = new();
 
-        public List<IWriteableBitmap> LayerBitmaps { get; set; } = new();
+        public List<LayerSource> LayerSources { get; set; } = new();
 
         public void CleanUp()
         {
             KraMainDoc = new();
             KraDocumentInfo = new();
-            LayerBitmaps.Clear();
+            LayerSources.Clear();
         }
 
         public void WriteFile()
@@ -36,35 +36,35 @@ namespace TgaBuilderLib.Krita
                 Directory.CreateDirectory(dir);
 
             // Decode every PNG into straight-alpha BGRA via Avalonia.
-            var layers = new List<LayerSource>();
-            int n = 0;
-            foreach (var layerBitmap in LayerBitmaps)
-            {
-                byte[] bgra = layerBitmap.ToMemoryStream().ToArray();
-                n++;
-                layers.Add(new LayerSource
-                {
-                    Name = $"Layer {n}",
-                    FileName = $"layer{n}",
-                    Bgra = bgra,
-                    Width = layerBitmap.PixelWidth,
-                    Height = layerBitmap.PixelHeight,
-                });
-            }
+            //var layers = new List<LayerSource>();
+            //int n = 0;
+            //foreach (var layerBitmap in LayerSources)
+            //{
+            //    byte[] bgra = layerBitmap.ToMemoryStream().ToArray();
+            //    n++;
+            //    layers.Add(new LayerSource
+            //    {
+            //        Name = $"Layer {n}",
+            //        FileName = $"layer{n}",
+            //        Bgra = bgra,
+            //        Width = layerBitmap.PixelWidth,
+            //        Height = layerBitmap.PixelHeight,
+            //    });
+            //}
 
-            if (layers.Count == 0)
+            if (LayerSources.Count == 0)
             {
                 throw new InvalidOperationException("No PNG files could be decoded.");
             }
 
-            int canvasW = layers.Max(l => l.Width);
-            int canvasH = layers.Max(l => l.Height);
+            int canvasW = LayerSources.Max(l => l.Width);
+            int canvasH = LayerSources.Max(l => l.Height);
 
             // Optional preview/merged image. Failure here must not abort the .kra itself.
             byte[]? mergedPng = null;
             byte[]? previewPng = null;
 
-            byte[] merged = Composite(layers, canvasW, canvasH);
+            byte[] merged = Composite(LayerSources, canvasW, canvasH);
             mergedPng = EncodePng(merged, canvasW, canvasH);
 
             byte[] small = Downscale(merged, canvasW, canvasH, 256, out int pw, out int ph);
@@ -78,7 +78,7 @@ namespace TgaBuilderLib.Krita
                             imageName: imageName,
                             canvasW: canvasW,
                             canvasH: canvasH,
-                            layers: layers,
+                            layers: LayerSources,
                             iccProfile: null,
                             mergedPng: mergedPng,
                             previewPng: previewPng);

--- a/TgaBuilderLib/Krita/KraWriter.cs
+++ b/TgaBuilderLib/Krita/KraWriter.cs
@@ -1,0 +1,93 @@
+using System.IO.Compression;
+using System.Text;
+
+namespace TgaBuilderLib.Krita;
+
+internal class KraWriter
+{
+    private const int PixelSize = 4; // RGBA8 -> 4 bytes, stored as B,G,R,A (Krita's native order)
+    private readonly string sRgbBuildInIccStr =
+    "AAACTGxjbXMEQAAAbW50clJHQiBYWVogB+oABgAFAA8AOAAfYWNzcEFQUEwAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+    "AAAAAAAPbWAAEAAAAA0y1sY21zAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+    "AAALZGVzYwAAAQgAAAA2Y3BydAAAAUAAAABMd3RwdAAAAYwAAAAUY2hhZAAAAaAAAAAsclhZWgAAAcwAAAAUYl" +
+    "hZWgAAAeAAAAAUZ1hZWgAAAfQAAAAUclRSQwAAAggAAAAgZ1RSQwAAAggAAAAgYlRSQwAAAggAAAAgY2hybQAA" +
+    "AigAAAAkbWx1YwAAAAAAAAABAAAADGVuVVMAAAAaAAAAHABzAFIARwBCACAAYgB1AGkAbAB0AC0AaQBuAABtbH" +
+    "VjAAAAAAAAAAEAAAAMZW5VUwAAADAAAAAcAE4AbwAgAGMAbwBwAHkAcgBpAGcAaAB0ACwAIAB1AHMAZQAgAGYA" +
+    "cgBlAGUAbAB5WFlaIAAAAAAAAPbWAAEAAAAA0y1zZjMyAAAAAAABDEIAAAXe///zJQAAB5MAAP2Q///7of///a" +
+    "IAAAPcAADAblhZWiAAAAAAAABvoAAAOPUAAAOQWFlaIAAAAAAAACSfAAAPhAAAtsNYWVogAAAAAAAAYpcAALeH" +
+    "AAAY2XBhcmEAAAAAAAMAAAACZmYAAPKnAAANWQAAE9AAAApbY2hybQAAAAAAAwAAAACj1wAAVHsAAEzNAACZmg" +
+    "AAJmYAAA9c";
+
+    /// <summary>
+    /// Writes a Krita .kra document combining <paramref name="layers"/> (index 0 = bottom layer)
+    /// onto a canvas of <paramref name="canvasW"/> x <paramref name="canvasH"/> pixels. Smaller
+    /// layers sit in the top-left corner (origin 0,0).
+    /// </summary>
+    public void Write(
+        string outputPath,
+        string imageName,
+        int canvasW,
+        int canvasH,
+        IReadOnlyList<LayerSource> layers,
+        byte[]? iccProfile = null,
+        byte[]? mergedPng = null,
+        byte[]? previewPng = null)
+    {
+        var mainDoc = new MainDoc
+        {
+            ImageName = imageName,
+            Width = canvasW,
+            Height = canvasH,
+            Layers = layers
+        };
+
+        var documentInfo = new DocumentInfo
+        {
+            ImageName = imageName,
+            InitialCreator = "TgaBuilder"
+        };
+
+        using var fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
+        using var zip = new ZipArchive(fs, ZipArchiveMode.Create);
+
+        // 1. mimetype MUST be the first entry and stored uncompressed.
+        WriteStored(zip, "mimetype", Encoding.ASCII.GetBytes("application/x-krita"));
+
+        // 2. maindoc.xml + documentinfo.xml
+        WriteDeflate(zip, "maindoc.xml", Encoding.UTF8.GetBytes(mainDoc.Build()));
+        WriteDeflate(zip, "documentinfo.xml", Encoding.UTF8.GetBytes(documentInfo.Build()));
+
+        // 3. per-layer pixel data + default pixel
+        foreach (var layer in layers)
+        {
+            var layerData = new LayerData(layer);
+            byte[] tiles = layerData.Build();
+            WriteDeflate(zip, $"{imageName}/layers/{layer.FileName}", tiles);
+            // transparent default pixel (4 zero bytes -> order irrelevant)
+            WriteDeflate(zip, $"{imageName}/layers/{layer.FileName}.defaultpixel", new byte[PixelSize]);
+            // icc per layer
+            WriteDeflate(zip, $"{imageName}/layers/{layer.FileName}.icc", iccProfile ?? Convert.FromBase64String(sRgbBuildInIccStr));
+        }
+
+        // 4. image colour profile annotation (Krita's built-in sRGB)
+        WriteDeflate(zip, $"{imageName}/annotations/icc", iccProfile ?? Convert.FromBase64String(sRgbBuildInIccStr));
+
+        // 5. optional previews
+        if (mergedPng != null) WriteDeflate(zip, "mergedimage.png", mergedPng);
+        if (previewPng != null) WriteDeflate(zip, "preview.png", previewPng);
+    }
+
+    private static void WriteStored(ZipArchive zip, string name, byte[] data)
+    {
+        var entry = zip.CreateEntry(name, CompressionLevel.NoCompression);
+        using var s = entry.Open();
+        s.Write(data, 0, data.Length);
+    }
+
+    private static void WriteDeflate(ZipArchive zip, string name, byte[] data)
+    {
+        var entry = zip.CreateEntry(name, CompressionLevel.Optimal);
+        using var s = entry.Open();
+        s.Write(data, 0, data.Length);
+    }
+}

--- a/TgaBuilderLib/Krita/KraWriter.cs
+++ b/TgaBuilderLib/Krita/KraWriter.cs
@@ -62,11 +62,11 @@ internal class KraWriter
         {
             var layerData = new LayerData(layer);
             byte[] tiles = layerData.Build();
-            WriteDeflate(zip, $"{imageName}/layers/{layer.FileName}", tiles);
+            WriteDeflate(zip, $"{imageName}/layers/{layer.Name}", tiles);
             // transparent default pixel (4 zero bytes -> order irrelevant)
-            WriteDeflate(zip, $"{imageName}/layers/{layer.FileName}.defaultpixel", new byte[PixelSize]);
+            WriteDeflate(zip, $"{imageName}/layers/{layer.Name}.defaultpixel", new byte[PixelSize]);
             // icc per layer
-            WriteDeflate(zip, $"{imageName}/layers/{layer.FileName}.icc", iccProfile ?? Convert.FromBase64String(sRgbBuildInIccStr));
+            WriteDeflate(zip, $"{imageName}/layers/{layer.Name}.icc", iccProfile ?? Convert.FromBase64String(sRgbBuildInIccStr));
         }
 
         // 4. image colour profile annotation (Krita's built-in sRGB)

--- a/TgaBuilderLib/Krita/KraWriter.cs
+++ b/TgaBuilderLib/Krita/KraWriter.cs
@@ -6,6 +6,34 @@ namespace TgaBuilderLib.Krita;
 internal class KraWriter
 {
     private const int PixelSize = 4; // RGBA8 -> 4 bytes, stored as B,G,R,A (Krita's native order)
+
+
+    /* Krita's information text regrading the sRGB build-in ICC profile
+     * 
+     * About RGB/Alpha (8-bit Ganzzahl pro Kanal)/sRGB built-in
+     * ========================================================
+     * ICC Version: 4.4
+     * ----------------
+     * Copyright: No copyright, use freely
+     * ----------------
+     * RGB (Red, Green, Blue) https://en.wikipedia.org/wiki/RGB_color_spaces, 
+     * is the color model used by screens and other light-based media.
+     * RGB is an additive color model: adding colors together makes them brighter. This color 
+     * model is the most extensive of all color models, and is recommended as a model for 
+     * painting,that you can later convert to other spaces. RGB is also the recommended 
+     * colorspace for HDR editing.
+     * ----------------
+     * 8 bit integer: 
+     * The default number of colors per channel. Each channel will have 256 
+     * values available, leading to a total amount of colors of 256 to the power of the 
+     * number of channels. Recommended to use for images intended for the web, or otherwise 
+     * simple images.
+     * The following conversion intents are possible: 
+     *  Relatively colorimetric
+     */
+    /// <summary>
+    /// Krita's sRGB build-in ICC profile base64 encoded
+    /// </summary>
     private readonly string sRgbBuildInIccStr =
     "AAACTGxjbXMEQAAAbW50clJHQiBYWVogB+oABgAFAA8AOAAfYWNzcEFQUEwAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
     "AAAAAAAPbWAAEAAAAA0y1sY21zAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
@@ -47,6 +75,10 @@ internal class KraWriter
             InitialCreator = "TgaBuilder"
         };
 
+        byte[] iccProfileBytes = iccProfile is null
+            ? Convert.FromBase64String(sRgbBuildInIccStr)
+            : iccProfile;
+
         using var fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
         using var zip = new ZipArchive(fs, ZipArchiveMode.Create);
 
@@ -66,11 +98,11 @@ internal class KraWriter
             // transparent default pixel (4 zero bytes -> order irrelevant)
             WriteDeflate(zip, $"{imageName}/layers/{layer.Name}.defaultpixel", new byte[PixelSize]);
             // icc per layer
-            WriteDeflate(zip, $"{imageName}/layers/{layer.Name}.icc", iccProfile ?? Convert.FromBase64String(sRgbBuildInIccStr));
+            WriteDeflate(zip, $"{imageName}/layers/{layer.Name}.icc", iccProfileBytes);
         }
 
         // 4. image colour profile annotation (Krita's built-in sRGB)
-        WriteDeflate(zip, $"{imageName}/annotations/icc", iccProfile ?? Convert.FromBase64String(sRgbBuildInIccStr));
+        WriteDeflate(zip, $"{imageName}/annotations/icc", iccProfileBytes);
 
         // 5. optional previews
         if (mergedPng != null) WriteDeflate(zip, "mergedimage.png", mergedPng);

--- a/TgaBuilderLib/Krita/LayerData.cs
+++ b/TgaBuilderLib/Krita/LayerData.cs
@@ -1,0 +1,133 @@
+using System.Text;
+
+namespace TgaBuilderLib.Krita;
+
+internal class LayerData
+{
+    private const int TileW = 64;
+    private const int TileH = 64;
+    private const int PixelSize = 4; // RGBA8 -> 4 bytes, stored as B,G,R,A (Krita's native order)
+
+    internal LayerSource Layer { get; set; }
+
+    internal LayerData(LayerSource layer)
+    {
+        Layer = layer;
+    }
+
+    /// <summary>
+    /// Serializes a paint layer's pixels into Krita's tiled paint-device format:
+    ///   VERSION/TILEWIDTH/TILEHEIGHT/PIXELSIZE/DATA header, then one block per
+    ///   non-empty 64x64 tile: "&lt;x&gt;,&lt;y&gt;,LZF,&lt;size&gt;\n" followed by
+    ///   [compressionFlag][payload].
+    /// </summary>
+    internal byte[] Build()
+    {
+        int tilesX = (Layer.Width + TileW - 1) / TileW;
+        int tilesY = (Layer.Height + TileH - 1) / TileH;
+
+        const int tileBytes = TileW * TileH * PixelSize; // Assumes PixelSize is 4 for BGRA
+        var compressBuf = new byte[tileBytes + tileBytes / 16 + 64];
+        var tile = new byte[tileBytes];
+
+        var bodies = new List<byte[]>();
+        int channelSize = TileW * TileH; // Size of a single channel plane within the tile
+
+        for (int ty = 0; ty < tilesY; ty++)
+        {
+            for (int tx = 0; tx < tilesX; tx++)
+            {
+                Array.Clear(tile, 0, tile.Length); // areas outside the image stay transparent
+
+                bool anyContent = false;
+                for (int row = 0; row < TileH; row++)
+                {
+                    int srcY = ty * TileH + row;
+                    if (srcY >= Layer.Height) break;
+
+                    int maxCol = Math.Min(TileW, Layer.Width - tx * TileW);
+                    int srcBase = (srcY * Layer.Width + tx * TileW) * PixelSize;
+
+                    for (int col = 0; col < maxCol; col++)
+                    {
+                        int srcIdx = srcBase + col * PixelSize;
+                        int pixelIndex = row * TileW + col;
+
+                        // Read interleaved BGRA from source
+                        byte b = Layer.Bgra[srcIdx + 2];
+                        byte g = Layer.Bgra[srcIdx + 1];
+                        byte r = Layer.Bgra[srcIdx + 0];
+                        byte a = Layer.Bgra[srcIdx + 3];
+
+                        // Write into planar RRRR...GGGG...BBBB...AAAA... destination
+                        tile[pixelIndex] = r;
+                        tile[channelSize + pixelIndex] = g;
+                        tile[2 * channelSize + pixelIndex] = b;
+                        tile[3 * channelSize + pixelIndex] = a;
+
+                        if (!anyContent && (r != 0 || g != 0 || b != 0 || a != 0))
+                        {
+                            anyContent = true;
+                        }
+                    }
+                }
+
+                if (!anyContent)
+                    continue; // fully transparent -> falls back to the default pixel
+
+                int xPix = tx * TileW;
+                int yPix = ty * TileH;
+
+                int compressed = Lzf.Compress(tile, tileBytes, compressBuf);
+
+                byte[] payload;
+                byte flag;
+                if (compressed > 0 && compressed < tileBytes)
+                {
+                    flag = 1; // LZF compressed
+                    payload = new byte[compressed];
+                    Buffer.BlockCopy(compressBuf, 0, payload, 0, compressed);
+                }
+                else
+                {
+                    flag = 0; // stored raw
+                    payload = (byte[])tile.Clone();
+                }
+
+                int storedSize = payload.Length + 1; // +1 for the flag byte
+                byte[] header = Encoding.ASCII.GetBytes($"{xPix},{yPix},LZF,{storedSize}\n");
+
+                var block = new byte[header.Length + storedSize];
+                Buffer.BlockCopy(header, 0, block, 0, header.Length);
+                block[header.Length] = flag;
+                Buffer.BlockCopy(payload, 0, block, header.Length + 1, payload.Length);
+                bodies.Add(block);
+            }
+        }
+        byte[] headerBytes = BuildHead(bodies.Count);
+
+        int total = headerBytes.Length + bodies.Sum(b => b.Length);
+        var result = new byte[total];
+        int pos = 0;
+        Buffer.BlockCopy(headerBytes, 0, result, pos, headerBytes.Length);
+        pos += headerBytes.Length;
+        foreach (var b in bodies)
+        {
+            Buffer.BlockCopy(b, 0, result, pos, b.Length);
+            pos += b.Length;
+        }
+        return result;
+    }
+
+    private static byte[] BuildHead(int bodiesCount)
+    {
+        var head = new StringBuilder();
+        head.Append("VERSION 2\n");
+        head.Append($"TILEWIDTH {TileW}\n");
+        head.Append($"TILEHEIGHT {TileH}\n");
+        head.Append($"PIXELSIZE {PixelSize}\n");
+        head.Append($"DATA {bodiesCount}\n");
+        byte[] headerBytes = Encoding.ASCII.GetBytes(head.ToString());
+        return headerBytes;
+    }
+}

--- a/TgaBuilderLib/Krita/LayerData.cs
+++ b/TgaBuilderLib/Krita/LayerData.cs
@@ -6,7 +6,7 @@ internal class LayerData
 {
     private const int TileW = 64;
     private const int TileH = 64;
-    private const int PixelSize = 4; // RGBA8 -> 4 bytes, stored as B,G,R,A (Krita's native order)
+    private const int KritaPixelSize = 4; // RGBA8 -> 4 bytes, stored as B,G,R,A (Krita's native order)
 
     internal LayerSource Layer { get; set; }
 
@@ -26,12 +26,16 @@ internal class LayerData
         int tilesX = (Layer.Width + TileW - 1) / TileW;
         int tilesY = (Layer.Height + TileH - 1) / TileH;
 
-        const int tileBytes = TileW * TileH * PixelSize; // Assumes PixelSize is 4 for BGRA
+        const int tileBytes = TileW * TileH * KritaPixelSize; // Assumes KritaPixelSize is 4 for BGRA
         var compressBuf = new byte[tileBytes + tileBytes / 16 + 64];
         var tile = new byte[tileBytes];
 
         var bodies = new List<byte[]>();
         int channelSize = TileW * TileH; // Size of a single channel plane within the tile
+
+        int pixelSize = Layer.HasAlpha ? 4 : 3; // Source pixel size (BGRA or RGB)
+
+        byte b, g, r, a;
 
         for (int ty = 0; ty < tilesY; ty++)
         {
@@ -46,24 +50,34 @@ internal class LayerData
                     if (srcY >= Layer.Height) break;
 
                     int maxCol = Math.Min(TileW, Layer.Width - tx * TileW);
-                    int srcBase = (srcY * Layer.Width + tx * TileW) * PixelSize;
+                    int srcBase = (srcY * Layer.Width + tx * TileW) * pixelSize;
 
                     for (int col = 0; col < maxCol; col++)
                     {
-                        int srcIdx = srcBase + col * PixelSize;
+                        int srcIdx = srcBase + col * pixelSize;
                         int pixelIndex = row * TileW + col;
 
-                        // Read interleaved BGRA from source
-                        byte b = Layer.Bgra[srcIdx + 2];
-                        byte g = Layer.Bgra[srcIdx + 1];
-                        byte r = Layer.Bgra[srcIdx + 0];
-                        byte a = Layer.Bgra[srcIdx + 3];
+                        // Read interleaved from source
+                        if (Layer.HasAlpha) // BGRA32 source
+                        {
+                            b = Layer.PixelBytes[srcIdx + 0]; //B
+                            g = Layer.PixelBytes[srcIdx + 1]; //G
+                            r = Layer.PixelBytes[srcIdx + 2]; //R
+                            a = Layer.PixelBytes[srcIdx + 3]; //A
+                        }
+                        else // RGB24 source
+                        {
+                            r = Layer.PixelBytes[srcIdx + 0]; //R
+                            g = Layer.PixelBytes[srcIdx + 1]; //G
+                            b = Layer.PixelBytes[srcIdx + 2]; //B
+                            a = 255; // Opaque if no alpha channel
+                        }
 
-                        // Write into planar RRRR...GGGG...BBBB...AAAA... destination
-                        tile[pixelIndex] = r;
-                        tile[channelSize + pixelIndex] = g;
-                        tile[2 * channelSize + pixelIndex] = b;
-                        tile[3 * channelSize + pixelIndex] = a;
+                        // Write into planar BBB...GGG...RRR...AAA... destination
+                        tile[/* 0 *    channelSize + */ pixelIndex] = b;
+                        tile[/* 1 *  */channelSize +    pixelIndex] = g;
+                        tile[   2 *    channelSize +    pixelIndex] = r;
+                        tile[   3 *    channelSize +    pixelIndex] = a;
 
                         if (!anyContent && (r != 0 || g != 0 || b != 0 || a != 0))
                         {
@@ -111,10 +125,10 @@ internal class LayerData
         int pos = 0;
         Buffer.BlockCopy(headerBytes, 0, result, pos, headerBytes.Length);
         pos += headerBytes.Length;
-        foreach (var b in bodies)
+        foreach (var body in bodies)
         {
-            Buffer.BlockCopy(b, 0, result, pos, b.Length);
-            pos += b.Length;
+            Buffer.BlockCopy(body, 0, result, pos, body.Length);
+            pos += body.Length;
         }
         return result;
     }
@@ -125,7 +139,7 @@ internal class LayerData
         head.Append("VERSION 2\n");
         head.Append($"TILEWIDTH {TileW}\n");
         head.Append($"TILEHEIGHT {TileH}\n");
-        head.Append($"PIXELSIZE {PixelSize}\n");
+        head.Append($"PIXELSIZE {KritaPixelSize}\n");
         head.Append($"DATA {bodiesCount}\n");
         byte[] headerBytes = Encoding.ASCII.GetBytes(head.ToString());
         return headerBytes;

--- a/TgaBuilderLib/Krita/LayerSource.cs
+++ b/TgaBuilderLib/Krita/LayerSource.cs
@@ -3,18 +3,19 @@ namespace TgaBuilderLib.Krita;
 /// <summary>One source image that becomes one paint layer.</summary>
 public sealed class LayerSource
 {
-    public LayerSource(byte[] bgra, int width, int height, string name = "")
+    public LayerSource(byte[] bgra, int width, int height, bool hasAlpha, string name = "")
     {
-        Bgra = bgra ?? throw new ArgumentNullException(nameof(bgra));
+        PixelBytes = bgra ?? throw new ArgumentNullException(nameof(bgra));
         Width = width;
         Height = height;
+        HasAlpha = hasAlpha;
         Name = name;
     }
 
-
-    public string Name;       // human readable layer name (the source file name)
-    public byte[] Bgra;       // straight-alpha BGRA8888, row-major, stride = Width*4
-    public int Width;
-    public int Height;
-    public string Uuid = "{" + Guid.NewGuid().ToString() + "}";
+    public readonly string Name;                     // human readable layer name (the source file name)
+    public readonly byte[] PixelBytes;               // straight-alpha BGRA8888, row-major, stride = Width*4
+    public readonly int Width;
+    public readonly int Height;
+    public readonly bool HasAlpha;
+    public readonly string Uuid = "{" + Guid.NewGuid().ToString() + "}";
 }

--- a/TgaBuilderLib/Krita/LayerSource.cs
+++ b/TgaBuilderLib/Krita/LayerSource.cs
@@ -1,0 +1,12 @@
+namespace TgaBuilderLib.Krita;
+
+/// <summary>One source image that becomes one paint layer.</summary>
+public sealed class LayerSource
+{
+    public required string Name;        // human readable layer name (the source file name)
+    public required string FileName;    // on-disk name inside the .kra (e.g. "layer1")
+    public required byte[] Bgra;        // straight-alpha BGRA8888, row-major, stride = Width*4
+    public required int Width;
+    public required int Height;
+    public string Uuid = "{" + Guid.NewGuid().ToString() + "}";
+}

--- a/TgaBuilderLib/Krita/LayerSource.cs
+++ b/TgaBuilderLib/Krita/LayerSource.cs
@@ -3,10 +3,18 @@ namespace TgaBuilderLib.Krita;
 /// <summary>One source image that becomes one paint layer.</summary>
 public sealed class LayerSource
 {
-    public required string Name;        // human readable layer name (the source file name)
-    public required string FileName;    // on-disk name inside the .kra (e.g. "layer1")
-    public required byte[] Bgra;        // straight-alpha BGRA8888, row-major, stride = Width*4
-    public required int Width;
-    public required int Height;
+    public LayerSource(byte[] bgra, int width, int height, string name = "")
+    {
+        Bgra = bgra ?? throw new ArgumentNullException(nameof(bgra));
+        Width = width;
+        Height = height;
+        Name = name;
+    }
+
+
+    public string Name;       // human readable layer name (the source file name)
+    public byte[] Bgra;       // straight-alpha BGRA8888, row-major, stride = Width*4
+    public int Width;
+    public int Height;
     public string Uuid = "{" + Guid.NewGuid().ToString() + "}";
 }

--- a/TgaBuilderLib/Krita/Lzf.cs
+++ b/TgaBuilderLib/Krita/Lzf.cs
@@ -1,0 +1,177 @@
+namespace TgaBuilderLib.Krita;
+
+/// <summary>
+/// liblzf-compatible LZF compressor.
+/// Krita stores raster tiles with the "LZF" scheme, which is exactly this format.
+/// Only compression is needed here; the produced stream is decodable by any liblzf
+/// decompressor regardless of the hashing strategy used while compressing.
+/// </summary>
+internal static class Lzf
+{
+    private const int HLOG = 16;
+    private const int HSIZE = 1 << HLOG;
+    private const int MAX_LIT = 1 << 5;            // 32
+    private const int MAX_OFF = 1 << 13;           // 8192
+    private const int MAX_REF = (1 << 8) + (1 << 3); // 264
+
+    /// <summary>
+    /// Compresses <paramref name="inLen"/> bytes of <paramref name="input"/> into
+    /// <paramref name="output"/>. Returns the number of bytes written, or 0 if the
+    /// data did not fit into <paramref name="output"/> (i.e. it expanded).
+    /// </summary>
+    public static int Compress(byte[] input, int inLen, byte[] output)
+    {
+        if (inLen < 3)
+        {
+            // Not enough bytes to form a back-reference; emit as literals.
+            return EmitAllLiterals(input, inLen, output);
+        }
+
+        int[] htab = new int[HSIZE];   // stores absolute positions; 0 == position 0 (excluded as ref)
+
+        int outLen = output.Length;
+        int ip = 0;
+        int op = 0;
+        int inEnd = inLen;
+
+        int lit = 0;
+        op++; // reserve control byte for the first literal run
+
+        uint hval = (uint)((input[ip] << 8) | input[ip + 1]);
+
+        while (ip < inEnd - 2)
+        {
+            hval = (hval << 8) | input[ip + 2];
+            int hslot = (int)(((hval >> (3 * 8 - HLOG)) - hval * 5) & (HSIZE - 1));
+            int reff = htab[hslot];
+            htab[hslot] = ip;
+
+            int off = ip - reff - 1;
+            if (off < MAX_OFF
+                && reff > 0                       // matches liblzf's "ref > in_data"
+                && input[reff + 2] == input[ip + 2]
+                && input[reff + 1] == input[ip + 1]
+                && input[reff] == input[ip])
+            {
+                int len = 2;
+                int maxlen = inEnd - ip - len;
+                maxlen = maxlen > MAX_REF ? MAX_REF : maxlen;
+
+                // Worst case we are about to write 3 control/data bytes + close a run.
+                if (op + 3 + 1 >= outLen)
+                {
+                    if (op - (lit == 0 ? 1 : 0) + 3 + 1 >= outLen)
+                        return 0;
+                }
+
+                output[op - lit - 1] = (byte)(lit - 1); // stop the current literal run
+                if (lit == 0) op--;                      // undo run if it was empty
+
+                do
+                {
+                    len++;
+                }
+                while (len < maxlen && input[reff + len] == input[ip + len]);
+
+                len -= 2; // len is now (#matched octets - 1)... encoded value
+                ip++;
+
+                if (len < 7)
+                {
+                    output[op++] = (byte)((off >> 8) + (len << 5));
+                }
+                else
+                {
+                    output[op++] = (byte)((off >> 8) + (7 << 5));
+                    output[op++] = (byte)(len - 7);
+                }
+
+                output[op++] = (byte)off;
+
+                lit = 0;
+                op++; // start a fresh literal run
+
+                ip += len + 1;
+
+                if (ip >= inEnd - 2)
+                    break;
+
+                // VERY_FAST: re-seed the hash table for the two positions before the
+                // resume point (liblzf does two "--ip" here, not one), so that no input
+                // byte is skipped when scanning resumes.
+                ip -= 2;
+                hval = (uint)((input[ip] << 8) | input[ip + 1]);
+
+                hval = (hval << 8) | input[ip + 2];
+                htab[(int)(((hval >> (3 * 8 - HLOG)) - hval * 5) & (HSIZE - 1))] = ip;
+                ip++;
+
+                hval = (hval << 8) | input[ip + 2];
+                htab[(int)(((hval >> (3 * 8 - HLOG)) - hval * 5) & (HSIZE - 1))] = ip;
+                ip++;
+            }
+            else
+            {
+                // literal byte
+                if (op >= outLen)
+                    return 0;
+
+                lit++;
+                output[op++] = input[ip++];
+
+                if (lit == MAX_LIT)
+                {
+                    output[op - lit - 1] = (byte)(lit - 1); // stop run
+                    lit = 0;
+                    op++; // start run
+                }
+            }
+        }
+
+        if (op + 3 > outLen) // at most 3 bytes may still be needed
+            return 0;
+
+        while (ip < inEnd)
+        {
+            lit++;
+            output[op++] = input[ip++];
+
+            if (lit == MAX_LIT)
+            {
+                output[op - lit - 1] = (byte)(lit - 1);
+                lit = 0;
+                op++;
+            }
+        }
+
+        output[op - lit - 1] = (byte)(lit - 1); // end run
+        if (lit == 0) op--;                      // undo run if empty
+
+        return op;
+    }
+
+    private static int EmitAllLiterals(byte[] input, int inLen, byte[] output)
+    {
+        int op = 0;
+        int ip = 0;
+        int lit = 0;
+        op++; // control byte
+
+        while (ip < inLen)
+        {
+            if (op >= output.Length) return 0;
+            lit++;
+            output[op++] = input[ip++];
+            if (lit == MAX_LIT)
+            {
+                output[op - lit - 1] = (byte)(lit - 1);
+                lit = 0;
+                op++;
+            }
+        }
+
+        output[op - lit - 1] = (byte)(lit - 1);
+        if (lit == 0) op--;
+        return op;
+    }
+}

--- a/TgaBuilderLib/Krita/MainDoc.cs
+++ b/TgaBuilderLib/Krita/MainDoc.cs
@@ -1,0 +1,42 @@
+using System.Text;
+
+namespace TgaBuilderLib.Krita;
+
+public class MainDoc
+{
+    public string ImageName { get; set; } = "Unnamed";
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public IReadOnlyList<LayerSource> Layers { get; set; } = new List<LayerSource>();
+
+    public string Build()
+    {
+        var sb = new StringBuilder();
+        sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.Append("<!DOCTYPE DOC PUBLIC '-//KDE//DTD krita 2.0//EN' 'http://www.calligra.org/DTD/krita-2.0.dtd'>\n");
+        sb.Append("<DOC xmlns=\"http://www.calligra.org/DTD/krita\" editor=\"Krita\" syntaxVersion=\"2.0\" kritaVersion=\"5.2.2\">\n");
+        sb.Append($" <IMAGE name=\"{Xml.Escape(ImageName)}\" mime=\"application/x-kra\" width=\"{Width}\" height=\"{Height}\"")
+          .Append(" x-res=\"100\" y-res=\"100\" colorspacename=\"RGBA\" profile=\"sRGB built-in\" description=\"\">\n");
+        sb.Append("  <layers>\n");
+
+        // Krita lists layers top-first; layers[0] is the bottom layer, so emit in reverse.
+        for (int i = Layers.Count - 1; i >= 0; i--)
+        {
+            var l = Layers[i];
+            sb.Append("   <layer ")
+              .Append($"name=\"{Xml.Escape(l.Name)}\" ")
+              .Append($"filename=\"{l.FileName}\" ")
+              .Append($"uuid=\"{l.Uuid}\" ")
+              .Append("nodetype=\"paintlayer\" colorspacename=\"RGBA\" compositeop=\"normal\" ")
+              .Append("opacity=\"255\" visible=\"1\" locked=\"0\" collapsed=\"0\" ")
+              .Append("x=\"0\" y=\"0\" intimeline=\"1\" colorlabel=\"0\" ")
+              .Append("channelflags=\"\" channellockflags=\"1111\" ")
+              .Append($"selected=\"{(i == Layers.Count - 1 ? "true" : "false")}\"/>\n");
+        }
+
+        sb.Append("  </layers>\n");
+        sb.Append(" </IMAGE>\n");
+        sb.Append("</DOC>\n");
+        return sb.ToString();
+    }
+}

--- a/TgaBuilderLib/Krita/MainDoc.cs
+++ b/TgaBuilderLib/Krita/MainDoc.cs
@@ -25,7 +25,7 @@ public class MainDoc
             var l = Layers[i];
             sb.Append("   <layer ")
               .Append($"name=\"{Xml.Escape(l.Name)}\" ")
-              .Append($"filename=\"{l.Name}\" ")
+              .Append($"filename=\"{Xml.Escape(l.Name)}\" ")
               .Append($"uuid=\"{l.Uuid}\" ")
               .Append("nodetype=\"paintlayer\" colorspacename=\"RGBA\" compositeop=\"normal\" ")
               .Append("opacity=\"255\" visible=\"1\" locked=\"0\" collapsed=\"0\" ")

--- a/TgaBuilderLib/Krita/MainDoc.cs
+++ b/TgaBuilderLib/Krita/MainDoc.cs
@@ -25,7 +25,7 @@ public class MainDoc
             var l = Layers[i];
             sb.Append("   <layer ")
               .Append($"name=\"{Xml.Escape(l.Name)}\" ")
-              .Append($"filename=\"{l.FileName}\" ")
+              .Append($"filename=\"{l.Name}\" ")
               .Append($"uuid=\"{l.Uuid}\" ")
               .Append("nodetype=\"paintlayer\" colorspacename=\"RGBA\" compositeop=\"normal\" ")
               .Append("opacity=\"255\" visible=\"1\" locked=\"0\" collapsed=\"0\" ")

--- a/TgaBuilderLib/Krita/Xml.cs
+++ b/TgaBuilderLib/Krita/Xml.cs
@@ -1,0 +1,11 @@
+namespace TgaBuilderLib.Krita;
+
+internal static class Xml
+{
+    public static string Escape(string s) => s
+        .Replace("&", "&amp;")        
+        .Replace("<", "&lt;")
+        .Replace(">", "&gt;")
+        .Replace("\"", "&quot;")
+        .Replace("'", "&apos;");
+}

--- a/TgaBuilderLib/ViewModel/IO/TargetIOViewModel.cs
+++ b/TgaBuilderLib/ViewModel/IO/TargetIOViewModel.cs
@@ -36,7 +36,7 @@ namespace TgaBuilderLib.ViewModel
 
         private const FileTypes WRITEABLE_FILE_TYPES =
             FileTypes.TGA | FileTypes.BMP | FileTypes.PNG | FileTypes.JPG
-            | FileTypes.JPEG;
+            | FileTypes.JPEG | FileTypes.KRA;
 
         private static bool IsHandleableSaveFileException(Exception e)
             => e is FileNotFoundException

--- a/TgaBuilderLib/ViewModel/Modifications/ModificationOutViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Modifications/ModificationOutViewModel.cs
@@ -56,7 +56,7 @@ public class ModificationOutViewModel : ThrottledViewModelBase
 
     private void OnRecalculationCompleted(object? sender, EventArgs e)
     {
-        using var ResLockedFrameBuffer = ImageOut.GetLocker();
+        using var ResLockedFrameBuffer = ImageOut.GetLocker(requiresRefresh: true);
 
         Marshal.Copy(
             source: _modificationHelper.PixelsOutput, 

--- a/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
@@ -237,7 +237,7 @@ public class TransitionOutViewModel : ThrottledViewModelBase
 
     private void OnRecalculationCompleted(object? sender, EventArgs e)
     {
-        using var ResLockedFrameBuffer = ResultImage.GetLocker();
+        using var ResLockedFrameBuffer = ResultImage.GetLocker(requiresRefresh: true);
 
         Marshal.Copy(
             source: _transitionHelper.PixelsResult, 

--- a/TgaBuilderWpfUi/App.DI.xaml.cs
+++ b/TgaBuilderWpfUi/App.DI.xaml.cs
@@ -19,6 +19,7 @@ using TgaBuilderWpfUi.View;
 using TgaBuilderWpfUi.Wrappers;
 using Application = System.Windows.Application;
 using Wpf.Ui.Appearance;
+using TgaBuilderLib.Krita;
 
 namespace TgaBuilderWpfUi
 {
@@ -73,6 +74,7 @@ namespace TgaBuilderWpfUi
 
         private void AddCoreServicesToProvider(IServiceCollection services)
         {
+            services.AddSingleton<IKraFileService, KraFileService>();
             services.AddSingleton<ITrngDecrypter, TrngDecrypter>();
             services.AddSingleton<IBitmapBytesIO, BitmapBytesIO>();
 

--- a/TgaBuilderWpfUi/Services/FileService.FileTypes.cs
+++ b/TgaBuilderWpfUi/Services/FileService.FileTypes.cs
@@ -70,6 +70,15 @@ namespace TgaBuilderWpfUi.Services
                 }
             },
             {
+                FileTypes.KRA,
+                new FileTypeInfo
+                {
+                    Extension = ".kra",
+                    Description = "Krita Project Files (*.kra)|*.kra",
+                    Title = "Open Krita Projec File"
+                }
+            },
+            {   
                 FileTypes.PHD,
                 new FileTypeInfo
                 {

--- a/TgaBuilderWpfUi/View/ModificationsWindow.xaml
+++ b/TgaBuilderWpfUi/View/ModificationsWindow.xaml
@@ -155,15 +155,6 @@
                                 MouseDown="InputImage_MouseDown" />
                         </Grid>
                     </Viewbox>
-                    <TextBlock
-                        Text="Input Image"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource TextFillColorTertiaryBrush}"
-                        d:Foreground="White"
-                        FontSize="18"
-                        Visibility="{Binding InitTextVisible, Converter={StaticResource BoolToVisibilityConverter}}"
-                        IsHitTestVisible="False" />
                 </Grid>
             </Border>
 

--- a/TgaBuilderWpfUi/View/TransitionWindow.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindow.xaml
@@ -395,7 +395,7 @@
             <!-- Smooth mode: Hardness / Widening / Shift sliders -->
             <local:TransitionWindowSmoothUserControl
                 DataContext="{Binding PivotVM}"
-                Visibility="{Binding IsSmoothMode, Converter={StaticResource BoolToVisibilityConverter}}" />
+                Visibility="{Binding DataContext.IsSmoothMode, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource BoolToVisibilityConverter}}" />
 
             <!-- Brick mode: scrollable expanders -->
             <ScrollViewer


### PR DESCRIPTION
Krita's .kra files are comfortable to build. This can help users to save layered image data, e.g. in the transition helper, moving on with a professional imaging tool, filling the gap to the capabilities this tool won't have.