### PR TITLE
Reuse transition buffers across recalcs instead of per-pass allocation

### DIFF
--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml
@@ -232,6 +232,7 @@
                 IsVisible="{Binding TransitionOutVM.IsLabelMapExpanded}"
                 Background="Transparent">
                 <Image
+                    x:Name="LabelMapImage"
                     Margin="0,4,0,0"
                     RenderOptions.BitmapInterpolationMode="None"
                     Source="{Binding TransitionOutVM.LabelMapImage, Converter={StaticResource WriteableBitmapConverter}}"

--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
@@ -40,7 +40,9 @@ namespace TgaBuilderAvaloniaUi.View
             if (viewModel is not TransitionViewModel vm)
             return;
 
-            vm.TransitionOutVM.VisualInvalidator = new VisualInvalidator(ResultImage);
+            vm.TransitionOutVM.ResultInvalidator = new VisualInvalidator(ResultImage);
+
+            vm.TransitionOutVM.LabelInvalidator = new VisualInvalidator(LabelMapImage);
         }
 
         private void SubscribeToLabelMapExpanded(INotifyPropertyChanged viewModel)

--- a/TgaBuilderLib/Transitions/ITransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/ITransitionHelper.cs
@@ -7,9 +7,11 @@ namespace TgaBuilderLib.Transitions
 {
     public interface ITransitionHelper
     {
+        bool IsActive { get; }
+
         // Source Image Dimensions
-        int Width { get; set; }
-        int Height { get; set; }
+        int Width { get; }
+        int Height { get; }
 
         byte[] Pixels1 { get; set; }
         byte[] Pixels2 { get; set; }

--- a/TgaBuilderLib/Transitions/ITransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/ITransitionHelper.cs
@@ -58,6 +58,7 @@ namespace TgaBuilderLib.Transitions
         int UnderfillingThreshold { get; set; }
 
         // Methods
+        void EnsureBuffers(int width, int height);
         void Mix();
         byte[] GetLabelMap();
         int GetLabelAtPixel(int x, int y);

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksAnalyze.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksAnalyze.cs
@@ -28,85 +28,69 @@ namespace TgaBuilderLib.Transitions
 
     public partial class TransitionHelper
     {
-
-        // Runs a watershed-style tile analysis and builds labels, centroids, and a debug map.
-        // Writes the labels into the reusable _labels buffer and returns the tile segment list.
         private List<TileSegment> BricksAnalyze(byte[] pixels)
         {
+
+            bool isGraySegmentation = SegmentationMethod == SegmentationMethod.Watershed
+            || SegmentationMethod == SegmentationMethod.BrickFit
+            || SegmentationMethod == SegmentationMethod.GridFit;
+
             int totalPixels = Width * Height;
 
-            // Reuse the cached label buffer. `filtered`/`filteredColorPixels` are reference aliases
-            // onto the appropriate scratch buffers (or the unfiltered inputs for FilterType.None).
-            int[] labels = _labels;
-            float[] filtered;
-            byte[] filteredColorPixels;
 
-            // 1. Compute grayscale values (fully overwrites _scratchGray, so no clear needed)
-            float[] gray = _scratchGray;
-            ComputeGrayValues(pixels, gray);
+            // 1. Pre-Processings
+            if (isGraySegmentation)
+                ComputeGrayValues(pixels, _scratchGray);
+            else
+                Array.Copy(pixels, _scratchFilteredColor, pixels.Length);
 
-            // 2. Initial Filter. The gray filters write only the interior [1..W-2, 1..H-2], so the
-            //    reused _scratchFiltered buffer must be cleared first to match the fresh-array
-            //    zero border the segmentation relies on. The color filters write only the interior
-            //    too, but seed their borders from the copied source pixels (same as the former
-            //    pixels.Clone()), so they need the copy rather than a clear.
-            switch (SelectedFilter)
+            // 2. Initial Filter. 
+
+            switch (SelectedFilter, isGraySegmentation)
             {
-                case FilterType.BoxBlur:
-                    filtered = _scratchFiltered;
-                    Array.Clear(filtered, 0, totalPixels);
-                    BoxBlurGray(filtered, gray);
-                    filteredColorPixels = _scratchFilteredColor;
-                    Array.Copy(pixels, filteredColorPixels, pixels.Length);
-                    BoxBlurColor(filteredColorPixels, pixels);
+                case (FilterType.BoxBlur, true):
+                    BoxBlurGray(_scratchFiltered, _scratchGray);
                     break;
-                case FilterType.Median:
-                    filtered = _scratchFiltered;
-                    Array.Clear(filtered, 0, totalPixels);
-                    MedianFilter3x3Gray(filtered, gray);
-                    filteredColorPixels = _scratchFilteredColor;
-                    Array.Copy(pixels, filteredColorPixels, pixels.Length);
-                    MedianFilter3x3Color(filteredColorPixels, pixels);
+                case (FilterType.BoxBlur, false):
+                    BoxBlurColor(_scratchFilteredColor, pixels);
                     break;
-                case FilterType.Bilateral:
-                    filtered = _scratchFiltered;
-                    Array.Clear(filtered, 0, totalPixels);
-                    BilateralFilter3x3Gray(filtered, gray, BilateralSigma);
-                    filteredColorPixels = _scratchFilteredColor;
-                    Array.Copy(pixels, filteredColorPixels, pixels.Length);
-                    BilateralFilter3x3Color(filteredColorPixels, pixels, BilateralSigma);
+                case (FilterType.Median, true):
+                    MedianFilter3x3Gray(_scratchFiltered, _scratchGray);
                     break;
-                case FilterType.Gaussian:
-                    filtered = _scratchFiltered;
-                    Array.Clear(filtered, 0, totalPixels);
-                    GaussianBlur3x3Gray(filtered, gray, GaussianSigma);
-                    filteredColorPixels = _scratchFilteredColor;
-                    Array.Copy(pixels, filteredColorPixels, pixels.Length);
-                    GaussianBlur3x3Color(filteredColorPixels, pixels, GaussianSigma);
+                case (FilterType.Median, false):
+                    MedianFilter3x3Color(_scratchFilteredColor, pixels);
+                    break;                
+                case (FilterType.Bilateral, true):
+                    BilateralFilter3x3Gray(_scratchFiltered, _scratchGray, BilateralSigma);
                     break;
-                case FilterType.None:
+                case (FilterType.Bilateral, false):
+                    BilateralFilter3x3Color(_scratchFilteredColor, pixels, BilateralSigma);
+                    break;                
+                case (FilterType.Gaussian, true):
+                    GaussianBlur3x3Gray(_scratchFiltered, _scratchGray, GaussianSigma);
+                    break;
+                case (FilterType.Gaussian, false):
+                    GaussianBlur3x3Color(_scratchFilteredColor, pixels, GaussianSigma);
+                    break;
                 default:
-                    filtered = gray;
-                    filteredColorPixels = pixels;
                     break;
             }
 
-            // 3. Segmentation (writes labels in place). Clear first so unassigned pixels read 0,
-            //    matching the former fresh int[] allocation.
-            Array.Clear(labels, 0, totalPixels);
+            // 3. Segmentation
+            Array.Clear(_labels, 0, totalPixels);
             int labelCount = SegmentationMethod switch
             {
-                SegmentationMethod.Felzenszwalb => Felzenszwalb(filteredColorPixels, labels, FelzenszwalbMinSize, FelzenszwalbScale),
-                SegmentationMethod.Slic => Slic(filteredColorPixels, labels, SlicSegmentCount, SlicCompactness),
-                SegmentationMethod.Quickshift => Quickshift(filteredColorPixels, labels, QuickshiftMaxDist, QuickshiftRatio),
-                SegmentationMethod.Watershed => Watershed(filtered, labels),
-                SegmentationMethod.BrickFit => BrickFit(filtered, labels, GridFitAngle),
-                SegmentationMethod.GridFit => GridFit(filtered, labels, GridFitAngle),
+                SegmentationMethod.Felzenszwalb => Felzenszwalb(_scratchFilteredColor, _labels, FelzenszwalbMinSize, FelzenszwalbScale),
+                SegmentationMethod.Slic => Slic(_scratchFilteredColor, _labels, SlicSegmentCount, SlicCompactness),
+                SegmentationMethod.Quickshift => Quickshift(_scratchFilteredColor, _labels, QuickshiftMaxDist, QuickshiftRatio),
+                SegmentationMethod.Watershed => Watershed(_scratchFiltered, _labels),
+                SegmentationMethod.BrickFit => BrickFit(_scratchFiltered, _labels, GridFitAngle),
+                SegmentationMethod.GridFit => GridFit(_scratchFiltered, _labels, GridFitAngle),
                 _ => 0
             };
 
             // 4. Build _tileSegmentList (centroids + pixel offsets)
-            var tileSegmentList = BuildTileSegmentList(labels, Width, Height, labelCount);
+            var tileSegmentList = BuildTileSegmentList(_labels, Width, Height, labelCount);
 
             return tileSegmentList;
         }

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksAnalyze.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksAnalyze.cs
@@ -30,39 +30,58 @@ namespace TgaBuilderLib.Transitions
     {
 
         // Runs a watershed-style tile analysis and builds labels, centroids, and a debug map.
-        private (int[] labels, List<TileSegment> tileSegmentList) BricksAnalyze(byte[] pixels)
+        // Writes the labels into the reusable _labels buffer and returns the tile segment list.
+        private List<TileSegment> BricksAnalyze(byte[] pixels)
         {
             int totalPixels = Width * Height;
 
-            float[] filtered = new float[totalPixels];
-            int[] labels = new int[totalPixels];
-            byte[] filteredColorPixels = pixels;
+            // Reuse the cached label buffer. `filtered`/`filteredColorPixels` are reference aliases
+            // onto the appropriate scratch buffers (or the unfiltered inputs for FilterType.None).
+            int[] labels = _labels;
+            float[] filtered;
+            byte[] filteredColorPixels;
 
-            // 1. Compute grayscale values
-            float[] gray = new float[totalPixels];
+            // 1. Compute grayscale values (fully overwrites _scratchGray, so no clear needed)
+            float[] gray = _scratchGray;
             ComputeGrayValues(pixels, gray);
 
-            // 2. Initial Filter
+            // 2. Initial Filter. The gray filters write only the interior [1..W-2, 1..H-2], so the
+            //    reused _scratchFiltered buffer must be cleared first to match the fresh-array
+            //    zero border the segmentation relies on. The color filters write only the interior
+            //    too, but seed their borders from the copied source pixels (same as the former
+            //    pixels.Clone()), so they need the copy rather than a clear.
             switch (SelectedFilter)
             {
                 case FilterType.BoxBlur:
+                    filtered = _scratchFiltered;
+                    Array.Clear(filtered, 0, totalPixels);
                     BoxBlurGray(filtered, gray);
-                    filteredColorPixels = (byte[])pixels.Clone();
+                    filteredColorPixels = _scratchFilteredColor;
+                    Array.Copy(pixels, filteredColorPixels, pixels.Length);
                     BoxBlurColor(filteredColorPixels, pixels);
                     break;
                 case FilterType.Median:
+                    filtered = _scratchFiltered;
+                    Array.Clear(filtered, 0, totalPixels);
                     MedianFilter3x3Gray(filtered, gray);
-                    filteredColorPixels = (byte[])pixels.Clone();
+                    filteredColorPixels = _scratchFilteredColor;
+                    Array.Copy(pixels, filteredColorPixels, pixels.Length);
                     MedianFilter3x3Color(filteredColorPixels, pixels);
                     break;
                 case FilterType.Bilateral:
+                    filtered = _scratchFiltered;
+                    Array.Clear(filtered, 0, totalPixels);
                     BilateralFilter3x3Gray(filtered, gray, BilateralSigma);
-                    filteredColorPixels = (byte[])pixels.Clone();
+                    filteredColorPixels = _scratchFilteredColor;
+                    Array.Copy(pixels, filteredColorPixels, pixels.Length);
                     BilateralFilter3x3Color(filteredColorPixels, pixels, BilateralSigma);
                     break;
                 case FilterType.Gaussian:
+                    filtered = _scratchFiltered;
+                    Array.Clear(filtered, 0, totalPixels);
                     GaussianBlur3x3Gray(filtered, gray, GaussianSigma);
-                    filteredColorPixels = (byte[])pixels.Clone();
+                    filteredColorPixels = _scratchFilteredColor;
+                    Array.Copy(pixels, filteredColorPixels, pixels.Length);
                     GaussianBlur3x3Color(filteredColorPixels, pixels, GaussianSigma);
                     break;
                 case FilterType.None:
@@ -72,7 +91,9 @@ namespace TgaBuilderLib.Transitions
                     break;
             }
 
-            // 3. Segmentation
+            // 3. Segmentation (writes labels in place). Clear first so unassigned pixels read 0,
+            //    matching the former fresh int[] allocation.
+            Array.Clear(labels, 0, totalPixels);
             int labelCount = SegmentationMethod switch
             {
                 SegmentationMethod.Felzenszwalb => Felzenszwalb(filteredColorPixels, labels, FelzenszwalbMinSize, FelzenszwalbScale),
@@ -87,7 +108,7 @@ namespace TgaBuilderLib.Transitions
             // 4. Build _tileSegmentList (centroids + pixel offsets)
             var tileSegmentList = BuildTileSegmentList(labels, Width, Height, labelCount);
 
-            return (labels, tileSegmentList);
+            return tileSegmentList;
         }
 
         private void ComputeGrayValues(byte[] pixels, float[] gray)

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksAnalyze.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksAnalyze.cs
@@ -72,6 +72,12 @@ namespace TgaBuilderLib.Transitions
                 case (FilterType.Gaussian, false):
                     GaussianBlur3x3Color(_scratchFilteredColor, pixels, GaussianSigma);
                     break;
+                case (FilterType.None, true):
+                    Array.Copy(_scratchGray, _scratchFiltered, totalPixels);
+                    break;
+                case (FilterType.None, false):
+                    Array.Copy(_scratchFilteredColor, pixels, totalPixels * TRANSITIONS_BPP);
+                    break;
                 default:
                     break;
             }

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
@@ -40,13 +40,136 @@ public partial class TransitionHelper
 
         byte[] shadowedBg = _scratchShadowedBg;
 
-        DrawShadows(bgPixels, selection, shadowedBg);
+        // Precompute the pixel-to-edge distance map once and reuse it for both passes. It depends
+        // only on the selection, so drawing-only recalcs (edge/shadow slider changes) reuse it.
+        if (!_edgeDistValid)
+        {
+            ComputeEdgeDistanceTransform(selection, _edgeDist);
+            _edgeDistValid = true;
+        }
 
-        DrawResult(tilePixels, selection, shadowedBg, result);
+        DrawShadows(bgPixels, selection, _edgeDist, shadowedBg);
+
+        DrawResult(tilePixels, selection, _edgeDist, shadowedBg, result);
     }
 
+    // Computes, for every pixel, the Chebyshev (L-infinity) distance to the nearest pixel of
+    // OPPOSITE selection state (min value 1; the INF sentinel when no opposite pixel exists).
+    // This is the same quantity the per-pixel ring searches in DrawShadows/DrawResult used to
+    // compute, but in O(Width*Height) via an exact two-pass (1,1) chamfer distance transform.
+    // The image border is intentionally NOT treated as a boundary: out-of-image neighbors are
+    // skipped, so border falloff stays driven solely by the dynamicSize cap in the draw passes
+    // (this mirrors the old out-of-bounds branch, which was dead code under that cap).
+    private void ComputeEdgeDistanceTransform(bool[] selection, int[] edgeDist)
+    {
+        int width = Width;
+        int height = Height;
+        int inf = width + height;
 
-    private void DrawShadows(byte[] bgPixels, bool[] selection, byte[] shadowedBg)
+        unsafe
+        {
+            fixed (bool* pSel = selection)
+            fixed (int* pDist = edgeDist)
+            {
+                // Seed pass: a pixel with an 8-connected neighbor of opposite state is distance 1
+                // from the boundary (D == 1, the global minimum); everything else starts at INF.
+                // Seeding with 1 (rather than 0) lets the two passes below converge directly to
+                // D(i) = distance to nearest opposite pixel, with no separate +1 fold.
+                for (int y = 0; y < height; y++)
+                {
+                    int row = y * width;
+                    for (int x = 0; x < width; x++)
+                    {
+                        int i = row + x;
+                        bool s = pSel[i];
+
+                        bool boundary = false;
+                        int yStart = y > 0 ? -1 : 0;
+                        int yEnd = y < height - 1 ? 1 : 0;
+                        int xStart = x > 0 ? -1 : 0;
+                        int xEnd = x < width - 1 ? 1 : 0;
+
+                        for (int dy = yStart; dy <= yEnd && !boundary; dy++)
+                        {
+                            int nRow = i + dy * width;
+                            for (int dx = xStart; dx <= xEnd; dx++)
+                            {
+                                if (dx == 0 && dy == 0)
+                                    continue;
+                                if (pSel[nRow + dx] != s)
+                                {
+                                    boundary = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        pDist[i] = boundary ? 1 : inf;
+                    }
+                }
+
+                // Forward pass: relax against NW, N, NE, W neighbors (finalized in raster order).
+                for (int y = 0; y < height; y++)
+                {
+                    int row = y * width;
+                    for (int x = 0; x < width; x++)
+                    {
+                        int i = row + x;
+                        int best = pDist[i];
+                        if (best == 1)
+                            continue; // already at the global minimum
+
+                        if (y > 0)
+                        {
+                            int up = i - width;
+                            best = MinPlusOne(best, pDist[up], inf);           // N
+                            if (x > 0) best = MinPlusOne(best, pDist[up - 1], inf);          // NW
+                            if (x < width - 1) best = MinPlusOne(best, pDist[up + 1], inf);  // NE
+                        }
+                        if (x > 0) best = MinPlusOne(best, pDist[i - 1], inf);  // W
+
+                        pDist[i] = best;
+                    }
+                }
+
+                // Backward pass: relax against SE, S, SW, E neighbors (finalized in reverse order).
+                for (int y = height - 1; y >= 0; y--)
+                {
+                    int row = y * width;
+                    for (int x = width - 1; x >= 0; x--)
+                    {
+                        int i = row + x;
+                        int best = pDist[i];
+                        if (best == 1)
+                            continue;
+
+                        if (y < height - 1)
+                        {
+                            int down = i + width;
+                            best = MinPlusOne(best, pDist[down], inf);          // S
+                            if (x < width - 1) best = MinPlusOne(best, pDist[down + 1], inf); // SE
+                            if (x > 0) best = MinPlusOne(best, pDist[down - 1], inf);         // SW
+                        }
+                        if (x < width - 1) best = MinPlusOne(best, pDist[i + 1], inf); // E
+
+                        pDist[i] = best;
+                    }
+                }
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    // Returns min(current, neighbor + 1), treating the INF sentinel as unreachable (no overflow).
+    private static int MinPlusOne(int current, int neighbor, int inf)
+    {
+        if (neighbor >= inf)
+            return current;
+        int candidate = neighbor + 1;
+        return candidate < current ? candidate : current;
+    }
+
+    private void DrawShadows(byte[] bgPixels, bool[] selection, int[] edgeDist, byte[] shadowedBg)
     {
         unsafe
         {
@@ -91,44 +214,8 @@ public partial class TransitionHelper
                         if (dynamicShadowSize <= 0)
                             continue;
 
-                        bool currentSelectionState = selection[pixelIndex];
-                        int minOppositeDist = dynamicShadowSize + 1;
-
-                        for (int d = 1; d <= dynamicShadowSize; d++)
-                        {
-                            bool foundOppositeSelection = false;
-
-                            for (int i = -d; i <= d; i++)
-                            {
-                                int topY = y - d;
-                                int botY = y + d;
-                                int xPlusI = x + i;
-
-                                if (topY >= 0 && topY < Height && xPlusI >= 0 && xPlusI < Width && selection[topY * Width + xPlusI] != currentSelectionState)
-                                    foundOppositeSelection = true;
-                                if (!foundOppositeSelection && botY >= 0 && botY < Height && xPlusI >= 0 && xPlusI < Width && selection[botY * Width + xPlusI] != currentSelectionState)
-                                    foundOppositeSelection = true;
-
-                                int leftX = x - d;
-                                int rightX = x + d;
-                                int yPlusI = y + i;
-                                if (!foundOppositeSelection && i > -d && i < d)
-                                {
-                                    if (leftX >= 0 && leftX < Width && yPlusI >= 0 && yPlusI < Height && selection[yPlusI * Width + leftX] != currentSelectionState)
-                                        foundOppositeSelection = true;
-                                    else if (rightX >= 0 && rightX < Width && yPlusI >= 0 && yPlusI < Height && selection[yPlusI * Width + rightX] != currentSelectionState)
-                                        foundOppositeSelection = true;
-                                }
-
-                                if (foundOppositeSelection) break;
-                            }
-
-                            if (foundOppositeSelection)
-                            {
-                                minOppositeDist = d;
-                                break;
-                            }
-                        }
+                        // Distance to the nearest opposite-selection pixel (precomputed).
+                        int minOppositeDist = edgeDist[pixelIndex];
 
                         if (minOppositeDist <= dynamicShadowSize)
                         {
@@ -155,8 +242,7 @@ public partial class TransitionHelper
         }
     }
 
-
-    private void DrawResult(byte[] tilePixels, bool[] selection, byte[] shadowedBg, byte[] result)
+    private void DrawResult(byte[] tilePixels, bool[] selection, int[] edgeDist, byte[] shadowedBg, byte[] result)
     {
         if (tilePixels.Length != shadowedBg.Length)
             throw new ArgumentException("Tile and shadow buffer must have the same length.");
@@ -206,54 +292,8 @@ public partial class TransitionHelper
                         int dynamicEdgeWidth = Math.Min(EdgeWidth, distToBorder);
                         if (selection[pixelIndex])
                         {
-                            int minDist = dynamicEdgeWidth + 1;
-
-                            // 2. Find the shortest distance to the next unselected pixel
-                            if (dynamicEdgeWidth > 0)
-                            {
-                                // Ring-like search outwards up to the 'dynamicEdgeWidth'
-                                for (int d = 1; d <= dynamicEdgeWidth; d++)
-                                {
-                                    bool foundEdge = false;
-
-                                    // Check the perimeter of the square at distance 'd'
-                                    for (int i = -d; i <= d; i++)
-                                    {
-                                        // Top and Bottom edges of the search square
-                                        int topY = y - d;
-                                        int botY = y + d;
-                                        int xPlusI = x + i;
-
-                                        // Check top boundary (out of bounds logic kept for safety,
-                                        // though dynamicEdgeWidth theoretically prevents it)
-                                        if (topY < 0 || topY >= Height || xPlusI < 0 || xPlusI >= Width || !selection[topY * Width + xPlusI])
-                                            foundEdge = true;
-                                        // Check bottom boundary
-                                        else if (botY < 0 || botY >= Height || xPlusI < 0 || xPlusI >= Width || !selection[botY * Width + xPlusI])
-                                            foundEdge = true;
-
-                                        // Left and Right edges (skip corners to avoid duplicate checks)
-                                        int leftX = x - d;
-                                        int rightX = x + d;
-                                        int yPlusI = y + i;
-                                        if (i > -d && i < d)
-                                        {
-                                            if (leftX < 0 || leftX >= Width || yPlusI < 0 || yPlusI >= Height || !selection[yPlusI * Width + leftX])
-                                                foundEdge = true;
-                                            else if (rightX < 0 || rightX >= Width || yPlusI < 0 || yPlusI >= Height || !selection[yPlusI * Width + rightX])
-                                                foundEdge = true;
-                                        }
-
-                                        if (foundEdge) break;
-                                    }
-
-                                    if (foundEdge)
-                                    {
-                                        minDist = d;
-                                        break; // Found the closest edge, stop searching
-                                    }
-                                }
-                            }
+                            // Distance to the nearest unselected pixel (precomputed).
+                            int minDist = edgeDist[pixelIndex];
 
                             // 3. Color the selected tile pixel based on the distance (Edge tint)
                             if (dynamicEdgeWidth > 0 && minDist <= dynamicEdgeWidth)

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
@@ -45,7 +45,7 @@ public partial class TransitionHelper
         DrawResult(tilePixels, selection, shadowedBg, result);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+
     private void DrawShadows(byte[] bgPixels, bool[] selection, byte[] shadowedBg)
     {
         unsafe
@@ -155,7 +155,7 @@ public partial class TransitionHelper
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+
     private void DrawResult(byte[] tilePixels, bool[] selection, byte[] shadowedBg, byte[] result)
     {
         if (tilePixels.Length != shadowedBg.Length)

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
@@ -22,7 +22,10 @@ public partial class TransitionHelper
         ColorBurn       // Darkens strongly with edge color
     }
 
-    private byte[] BricksDraw(byte[] tilePixels, byte[] bgPixels, bool[] selection)
+    // Writes the blended transition into the caller-provided result buffer using the reusable
+    // _scratchShadowedBg buffer for the intermediate shadow pass. Both buffers are fully
+    // overwritten via Buffer.MemoryCopy before any per-pixel work, so reuse leaves no stale data.
+    private void BricksDraw(byte[] tilePixels, byte[] bgPixels, bool[] selection, byte[] result)
     {
         if (bgPixels.Length != tilePixels.Length)
             throw new ArgumentException("Input image raw arrays must have same length.");
@@ -35,16 +38,11 @@ public partial class TransitionHelper
         ShadowSize = Math.Clamp(ShadowSize, 0, 32);
         ShadowHardness = Math.Clamp(ShadowHardness, 0, 100);
 
-        int stride = Width * TRANSITIONS_BPP;
-        var shadowedBg = new byte[bgPixels.Length];
-        var result = new byte[bgPixels.Length];
+        byte[] shadowedBg = _scratchShadowedBg;
 
         DrawShadows(bgPixels, selection, shadowedBg);
 
         DrawResult(tilePixels, selection, shadowedBg, result);
-
-        return result;
-
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksLabelMap.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksLabelMap.cs
@@ -16,7 +16,7 @@ public partial class TransitionHelper
         if (x < 0 || x >= Width || y < 0 || y >= Height)
             return 0;
 
-        if (_labels.Length == 0)
+        if (!_labelsBuilt)
             return 0;
 
         int index = y * Width + x;
@@ -24,23 +24,25 @@ public partial class TransitionHelper
     }
     public byte[] GetLabelMap()
     {
-        int[] currentLabels = new int[Width * Height];
-        int labelCount = _labels[0];
+        if (!_labelsBuilt)
+            return Array.Empty<byte>();
 
-        for (int i = 0; i < _labels.Length; i++)
+        int totalPixels = Width * Height;
+
+        // Find the highest label by scanning _labels directly (no throwaway copy).
+        int labelCount = 0;
+        for (int i = 0; i < totalPixels; i++)
         {
             int label = _labels[i];
-
-            currentLabels[i] = label;
-
             if (label > labelCount)
                 labelCount = label;
         }
 
         int stride = Width * TRANSITIONS_BPP;
 
-        // Create target array
-        byte[] map = new byte[Width * Height * TRANSITIONS_BPP];
+        // Reuse the owned label-map buffer. Every pixel is written below (label 0 → opaque black,
+        // otherwise the deterministic color), so no clear is needed.
+        byte[] map = _scratchLabelMap;
 
         // Generate colors deterministically
         uint[] colors = new uint[labelCount + 1];
@@ -59,7 +61,7 @@ public partial class TransitionHelper
         unsafe
         {
             fixed (byte* pDebug = map)
-            fixed (int* pLabels = currentLabels)
+            fixed (int* pLabels = _labels)
             {
                 for (int y = 0; y < Height; y++)
                 {
@@ -88,25 +90,19 @@ public partial class TransitionHelper
     // Gets a debug map highlighting the tile at (xPos, yPos) with the specified color, or gray if no color is provided.
     public byte[] GetTileIndicator(int tileIndex)
     {
-        int[] currentLabels = new int[Width * Height];
-        int labelCount = _labels[0];
+        if (!_labelsBuilt)
+            return Array.Empty<byte>();
 
-        for (int i = 0; i < _labels.Length; i++)
-        {
-            int label = _labels[i];
-
-            currentLabels[i] = label;
-
-            if (label > labelCount)
-                labelCount = label;
-        }
-
+        int totalPixels = Width * Height;
         int requestedLabel = tileIndex;
 
         int stride = Width * TRANSITIONS_BPP;
 
-        // Create target array
-        byte[] map = new byte[Width * Height * TRANSITIONS_BPP];
+        // Reuse the owned label-map buffer. Only the matching-label pixels are written below, so
+        // it must be cleared first to keep non-matching pixels transparent (matching the former
+        // freshly allocated, zero-initialized array).
+        byte[] map = _scratchLabelMap;
+        Array.Clear(map, 0, totalPixels * TRANSITIONS_BPP);
 
 
         byte r = _systemAccentColor.R;
@@ -119,7 +115,7 @@ public partial class TransitionHelper
         unsafe
         {
             fixed (byte* pDebug = map)
-            fixed (int* pLabels = currentLabels)
+            fixed (int* pLabels = _labels)
             {
                 for (int y = 0; y < Height; y++)
                 {

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksSelection.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksSelection.cs
@@ -14,12 +14,16 @@ public partial class TransitionHelper
     // a per-pixel topology test for corner tiles when SliceCornerTiles is enabled.
     // The per-pixel cut uses the same ComputeFocus logic as MixSmooth at hardness=1 and
     // offset=0, so the resulting border exactly follows the ComputeTopology boundary.
-    private bool[] BuildSelection(
+    private void BuildSelection(
         List<TileSegment> tileSegments,
         int[] labels,
         byte[] tilePixels)
     {
-        bool[] selection = new bool[Width * Height];
+        // Reuse the cached selection buffer. It is cleared here because the logic below only sets
+        // pixels to true (it never resets them), so stale trues from a previous recalc must not
+        // leak through.
+        bool[] selection = _selection;
+        Array.Clear(selection, 0, Width * Height);
         int labelCount = tileSegments.Count;
 
         TransitionDirection mode = Direction;
@@ -100,8 +104,6 @@ public partial class TransitionHelper
 
         if (UnderfillingThreshold > 0)
             SubstractUnderfilled(selection, tilePixels);
-
-        return selection;
     }
 
     private void SubstractUnderfilled(bool[] selection, byte[] tilePixels)

--- a/TgaBuilderLib/Transitions/TransitionHelper.MixBricks.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.MixBricks.cs
@@ -39,6 +39,7 @@ partial class TransitionHelper
         {
             BuildSelection(_tileSegmentList, _labels, tilePixels);
             _selectionBuilt = true;
+            _edgeDistValid = false; // selection changed → edge-distance map must be recomputed
         }
 
 

--- a/TgaBuilderLib/Transitions/TransitionHelper.MixBricks.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.MixBricks.cs
@@ -4,61 +4,46 @@ partial class TransitionHelper
 {
     // Draws segmented tile pixels over a background using a pixel selection derived from
     // tile topology and optional corner slicing. Pipeline: Input → Label Map → _selection → Result.
-    public byte[] MixBricks(
+    // Each pipeline stage writes directly into the reusable cached buffers (_labels, _selection)
+    // and the caller-provided result buffer, so no per-recalc allocation occurs here.
+    public void MixBricks(
       byte[] tilePixels,
-      byte[] bgPixels)
+      byte[] bgPixels,
+      byte[] result)
     {
         if (bgPixels.Length != tilePixels.Length)
             throw new ArgumentException("Pixel arrays must have same length.");
 
 
         // Requirements correction in case this is first time use
-        if (_labels.Length == 0|| _tileSegmentList.Count == 0)
+        if (!_labelsBuilt || _tileSegmentList.Count == 0)
             CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresAnalysis;
 
-        // Pipeline step 1: Analyze tile segments to build Label Map (Input → Label Map)
-        var currentLabels = new int[_labels.Length];
-        var currentTileSegments = new List<TileSegment>();
-        (currentLabels, currentTileSegments) = CurrentBricksPipelineRequirements == BricksPipelineRequirements.RequiresAnalysis
-            ? BricksAnalyze(tilePixels)
-            : (_labels, _tileSegmentList);
+        // Pipeline step 1: Analyze tile segments to build Label Map (Input → Label Map).
+        // Writes _labels in place and refreshes _tileSegmentList.
+        if (CurrentBricksPipelineRequirements == BricksPipelineRequirements.RequiresAnalysis)
+        {
+            _tileSegmentList = BricksAnalyze(tilePixels);
+            _labelsBuilt = true;
+        }
 
 
         // Requirements correction in case this is first time use
-        if (_selection.Length == 0
+        if (!_selectionBuilt
             && CurrentBricksPipelineRequirements > BricksPipelineRequirements.RequiresSelectionBuilding)
             CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresSelectionBuilding;
 
-        // Pipeline step 2: Determine which pixels are drawn (Input → Label Map → _selection)
-        var currentSelection = new bool[Width * Height];
-        currentSelection = CurrentBricksPipelineRequirements <= BricksPipelineRequirements.RequiresSelectionBuilding
-            ? BuildSelection(currentTileSegments, currentLabels, tilePixels)
-            : _selection;
-
-
-        // Pipeline step 3: Blend selected tile pixels with background based on edge proximity and EdgeColor (_selection → Result)
-        // If statement here, todo
-        byte[] result = BricksDraw(tilePixels, bgPixels, currentSelection);
-
-
-        // Write back pipeline results to properties for reuse
-        switch (CurrentBricksPipelineRequirements)
+        // Pipeline step 2: Determine which pixels are drawn (Input → Label Map → _selection).
+        // Writes _selection in place.
+        if (CurrentBricksPipelineRequirements <= BricksPipelineRequirements.RequiresSelectionBuilding)
         {
-            case BricksPipelineRequirements.RequiresAnalysis:
-                _labels = currentLabels;
-                _tileSegmentList = currentTileSegments;
-                goto case BricksPipelineRequirements.RequiresSelectionBuilding;
-
-            case BricksPipelineRequirements.RequiresSelectionBuilding:
-                _selection = currentSelection;
-                goto case BricksPipelineRequirements.RequiresDrawing;
-
-            case BricksPipelineRequirements.RequiresDrawing:
-                break;
-            default:
-                break;
+            BuildSelection(_tileSegmentList, _labels, tilePixels);
+            _selectionBuilt = true;
         }
 
-        return result;
+
+        // Pipeline step 3: Blend selected tile pixels with background based on edge proximity and
+        // EdgeColor (_selection → Result). Writes the caller-provided result buffer in place.
+        BricksDraw(tilePixels, bgPixels, _selection, result);
     }
 }

--- a/TgaBuilderLib/Transitions/TransitionHelper.MixSmooth.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.MixSmooth.cs
@@ -6,9 +6,12 @@ public partial class TransitionHelper
 {
 
     // Mixes two pixel buffers into one based on transition mode, pivot, and hardness.
-    public byte[] MixSmooth(
+    // Writes into the caller-provided result buffer (fully overwritten, every pixel) so no
+    // per-recalc allocation occurs.
+    public void MixSmooth(
         byte[] pixels1,
-        byte[] pixels2)
+        byte[] pixels2,
+        byte[] result)
     {
         if (pixels1.Length != pixels2.Length)
             throw new ArgumentException("Pixel arrays must have same length.");
@@ -16,8 +19,6 @@ public partial class TransitionHelper
         Hardness = Math.Clamp(Hardness, 0.0f, 1.0f);
         Pivot = Math.Clamp(Pivot, 0.0f, 1.0f);
         Widening = Math.Clamp(Widening, 0.0f, 1.0f);
-
-        byte[] result = new byte[pixels1.Length];
 
         float lower = Pivot * Hardness;
         float upper = 1.0f - (1.0f - Pivot) * Hardness;
@@ -57,8 +58,6 @@ public partial class TransitionHelper
                 }
             }
         }
-
-        return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/TgaBuilderLib/Transitions/TransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.cs
@@ -88,28 +88,6 @@ public partial class TransitionHelper : ITransitionHelper
             MixBricks(Pixels1, Pixels2, PixelsResult);
     }
 
-    //public void SetUp()
-    //{
-    //    _labels = new int[INIT_SIZE * INIT_SIZE];
-    //    _tileSegmentList = new List<TileSegment>();
-    //    _selection = new bool[INIT_SIZE * INIT_SIZE];
-    //    // Release the reusable scratch buffers so their memory can be reclaimed while the
-    //    // view is closed.
-    //    _scratchFiltered = new float[INIT_SIZE * INIT_SIZE];
-    //    _scratchGray = new float[INIT_SIZE * INIT_SIZE];
-    //    _scratchFilteredColor = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
-    //    _scratchShadowedBg = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
-    //    _scratchLabelMap = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
-//
-    //    Width = INIT_SIZE;
-    //    Height = INIT_SIZE;
-    //    Pixels1 = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
-    //    Pixels2 = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
-    //    PixelsResult = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
-//
-    //    IsActive = true;
-    //}
-
     public void CleanUp()
     {
         _labels = Array.Empty<int>();

--- a/TgaBuilderLib/Transitions/TransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.cs
@@ -29,6 +29,22 @@ namespace TgaBuilderLib.Transitions
         private List<TileSegment> _tileSegmentList = new();
         private bool[] _selection = Array.Empty<bool>();
 
+        // Reusable scratch buffers provisioned by EnsureBuffers when the view opens or the
+        // input picture sizes change, reused across recalcs, and released in CleanUp.
+        private float[] _scratchFiltered = Array.Empty<float>();
+        private float[] _scratchGray = Array.Empty<float>();
+        private byte[] _scratchFilteredColor = Array.Empty<byte>();
+        private byte[] _scratchShadowedBg = Array.Empty<byte>();
+        private byte[] _scratchLabelMap = Array.Empty<byte>();
+
+        private int _provisionedWidth;
+        private int _provisionedHeight;
+
+        // Because _labels/_selection are now pre-provisioned (length is always Width*Height),
+        // their array length can no longer signal "never computed". These flags do.
+        private bool _labelsBuilt;
+        private bool _selectionBuilt;
+
         public int Width { get; set; } = 64;
         public int Height { get; set; } = 64;
 
@@ -78,9 +94,43 @@ namespace TgaBuilderLib.Transitions
         public void Mix()
         {
             if (TypeOfTransition == TransitionType.Smooth)
-                PixelsResult = MixSmooth(Pixels1, Pixels2);
+                MixSmooth(Pixels1, Pixels2, PixelsResult);
             else
-                PixelsResult = MixBricks(Pixels1, Pixels2);
+                MixBricks(Pixels1, Pixels2, PixelsResult);
+        }
+
+        // Provisions the reusable buffer set for the given input picture size. Called when the
+        // transitions view opens and whenever the input picture dimensions change. Cheap no-op
+        // when the size is unchanged, so callers may invoke it freely.
+        public void EnsureBuffers(int width, int height)
+        {
+            int n = width * height;
+
+            if (width == _provisionedWidth
+                && height == _provisionedHeight
+                && _scratchFiltered.Length == n)
+                return;
+
+            int n4 = n * TRANSITIONS_BPP;
+
+            Pixels1 = new byte[n4];
+            Pixels2 = new byte[n4];
+            PixelsResult = new byte[n4];
+
+            _labels = new int[n];
+            _selection = new bool[n];
+
+            _scratchFiltered = new float[n];
+            _scratchGray = new float[n];
+            _scratchFilteredColor = new byte[n4];
+            _scratchShadowedBg = new byte[n4];
+            _scratchLabelMap = new byte[n4];
+
+            _provisionedWidth = width;
+            _provisionedHeight = height;
+
+            _labelsBuilt = false;
+            _selectionBuilt = false;
         }
 
         public void CleanUp()
@@ -88,6 +138,19 @@ namespace TgaBuilderLib.Transitions
             _labels = Array.Empty<int>();
             _tileSegmentList = new List<TileSegment>();
             _selection = Array.Empty<bool>();
+
+            // Release the reusable scratch buffers so their memory can be reclaimed while the
+            // view is closed.
+            _scratchFiltered = Array.Empty<float>();
+            _scratchGray = Array.Empty<float>();
+            _scratchFilteredColor = Array.Empty<byte>();
+            _scratchShadowedBg = Array.Empty<byte>();
+            _scratchLabelMap = Array.Empty<byte>();
+
+            _provisionedWidth = 0;
+            _provisionedHeight = 0;
+            _labelsBuilt = false;
+            _selectionBuilt = false;
 
             Width = 64;
             Height = 64;

--- a/TgaBuilderLib/Transitions/TransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.cs
@@ -4,192 +4,157 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using TgaBuilderLib.Abstraction;
 
-namespace TgaBuilderLib.Transitions
-{
-    public partial class TransitionHelper : ITransitionHelper
-    {
-        public TransitionHelper(Color? AccentColor = null) 
-        { 
-            _systemAccentColor = AccentColor ?? new Color(128, 128, 128, 128);
-            Pixels1 = new byte[64 * 64 * TRANSITIONS_BPP];
-            Pixels2 = new byte[64 * 64 * TRANSITIONS_BPP];
-            PixelsResult = new byte[64 * 64 * TRANSITIONS_BPP];
-        }
-        private readonly Color _systemAccentColor;
-        private const int TRANSITIONS_BPP = 4; // Always BGRA32
+namespace TgaBuilderLib.Transitions; 
+public partial class TransitionHelper : ITransitionHelper
+{ 
+    private const int TRANSITIONS_BPP = 4; // Always BGRA32 
+    private const int INIT_SIZE = 64;
 
 
-        public byte[] Pixels1 { get; set; }
-        public byte[] Pixels2 { get; set; }
-
-        public byte[] PixelsResult { get; set; }
-
-
-        private int[] _labels = new int[64 * 64];
-        private List<TileSegment> _tileSegmentList = new();
-        private bool[] _selection = new bool[64 * 64];
-
-        // Reusable scratch buffers provisioned by EnsureBuffers when the view opens or the
-        // input picture sizes change, reused across recalcs, and released in CleanUp.
-        private float[] _scratchFiltered = new float[64 * 64];
-        private float[] _scratchGray = new float[64 * 64];
-        private byte[] _scratchFilteredColor = new byte[64 * 64 * TRANSITIONS_BPP];
-        private byte[] _scratchShadowedBg = new byte[64 * 64 * TRANSITIONS_BPP];
-        private byte[] _scratchLabelMap = new byte[64 * 64 * TRANSITIONS_BPP];
-
-        private int _provisionedWidth;
-        private int _provisionedHeight;
-
-        // Because _labels/_selection are now pre-provisioned (length is always Width*Height),
-        // their array length can no longer signal "never computed". These flags do.
-        private bool _labelsBuilt;
-        private bool _selectionBuilt;
-
-        public int Width { get; set; } = 64;
-        public int Height { get; set; } = 64;
-
-        public TransitionType TypeOfTransition { get; set; }
-
-        public TransitionDirection Direction { get; set; }
-        public float Pivot { get; set; } = 0.5f;
-
-        public float Hardness { get; set; } = 0.5f;
-        public float Widening { get; set; } = 0f;
-        public float Shift { get; set; } = 0f;
-
-
-        public BricksPipelineRequirements CurrentBricksPipelineRequirements { get; set; }
-            = BricksPipelineRequirements.RequiresAnalysis;
-        public bool ReversePivot { get; set; } = false;
-        public bool InvertGrayscale { get; set; } = false;
-        public bool SliceCornerTiles { get; set; } = false;
-        public bool ProtectEdges { get; set; } = true;
-        public int MarkerCount { get; set; } = 42;
-        public int MarkerRadius { get; set; } = 5;
-        public float GridFitAngle { get; set; } = 0f;
-        public SegmentationMethod SegmentationMethod { get; set; } = SegmentationMethod.Felzenszwalb;
-        public int FelzenszwalbMinSize { get; set; } = 50;
-        public float FelzenszwalbScale { get; set; } = 100f;
-        public int SlicSegmentCount { get; set; } = 250;
-        public float SlicCompactness { get; set; } = 10f;
-        public int QuickshiftMaxDist { get; set; } = 10;
-        public float QuickshiftRatio { get; set; } = 1f;
-        public FilterType SelectedFilter { get; set; } = FilterType.Gaussian;
-        public float BilateralSigma { get; set; } = 30f;
-        public float GaussianSigma { get; set; } = 1f;
-
-        public float UnderfillingPivot { get; set; } = 0.5f;
-        public bool ReverseUnderfilling { get; set; } = false;
-        public int UnderfillingThreshold { get; set; } = 0;
-
-        public Color EdgeColor { get; set; } = new Color(255, 255, 255, 128);
-        public EdgeBlendMode BlendMode { get; set; } = EdgeBlendMode.Multiply;
-        public int EdgeWidth { get; set; } = 1;
-        public Color ShadowColor { get; set; } = new Color(42, 42, 42, 42);
-        public int ShadowSize { get; set; } = 3;
-        public int ShadowHardness { get; set; } = 50;
-
-        public event EventHandler? RecalculationCompleted;
-
-        public void Mix()
-        {
-            if (TypeOfTransition == TransitionType.Smooth)
-                MixSmooth(Pixels1, Pixels2, PixelsResult);
-            else
-                MixBricks(Pixels1, Pixels2, PixelsResult);
-        }
-
-        // Provisions the reusable buffer set for the given input picture size. Called when the
-        // transitions view opens and whenever the input picture dimensions change. Cheap no-op
-        // when the size is unchanged, so callers may invoke it freely.
-        public void EnsureBuffers(int width, int height)
-        {
-            int n = width * height;
-
-            if (width == _provisionedWidth
-                && height == _provisionedHeight
-                && _scratchFiltered.Length == n)
-                return;
-
-            int n4 = n * TRANSITIONS_BPP;
-
-            Pixels1 = new byte[n4];
-            Pixels2 = new byte[n4];
-            PixelsResult = new byte[n4];
-
-            _labels = new int[n];
-            _selection = new bool[n];
-
-            _scratchFiltered = new float[n];
-            _scratchGray = new float[n];
-            _scratchFilteredColor = new byte[n4];
-            _scratchShadowedBg = new byte[n4];
-            _scratchLabelMap = new byte[n4];
-
-            _provisionedWidth = width;
-            _provisionedHeight = height;
-
-            _labelsBuilt = false;
-            _selectionBuilt = false;
-        }
-
-        public void CleanUp()
-        {
-            _labels = new int[64 * 64];
-            _tileSegmentList = new List<TileSegment>();
-            _selection = new bool[64 * 64];
-
-            // Release the reusable scratch buffers so their memory can be reclaimed while the
-            // view is closed.
-            _scratchFiltered = new float[64 * 64];
-            _scratchGray = new float[64 * 64];
-            _scratchFilteredColor = new byte[64 * 64 * TRANSITIONS_BPP];
-            _scratchShadowedBg = new byte[64 * 64 * TRANSITIONS_BPP];
-            _scratchLabelMap = new byte[64 * 64 * TRANSITIONS_BPP];
-
-            _provisionedWidth = 0;
-            _provisionedHeight = 0;
-            _labelsBuilt = false;
-            _selectionBuilt = false;
-
-            Width = 64;
-            Height = 64;
-
-            Pixels1 = new byte[64 * 64 * TRANSITIONS_BPP];
-            Pixels2 = new byte[64 * 64 * TRANSITIONS_BPP];
-            PixelsResult = new byte[64 * 64 * TRANSITIONS_BPP];
-
-            Direction = TransitionDirection.Top;
-            Pivot = 0.5f;
-
-            Hardness = 0.5f;
-            Widening = 0f;
-
-            MarkerCount = 42; 
-            MarkerRadius = 5;
-            GridFitAngle = 0f;
-            ReversePivot = false;
-            SliceCornerTiles = false;
-            ProtectEdges = true;
-            SegmentationMethod = SegmentationMethod.Felzenszwalb;
-            FelzenszwalbMinSize = 50;
-            FelzenszwalbScale = 100f;
-            SlicSegmentCount = 250;
-            SlicCompactness = 10f;
-            QuickshiftMaxDist = 10;
-            QuickshiftRatio = 1f;
-            SelectedFilter = FilterType.BoxBlur;
-            BilateralSigma = 30f;
-            GaussianSigma = 1f;
-            EdgeColor = new Color(0, 0, 0, 128);
-            BlendMode = EdgeBlendMode.Multiply;
-            EdgeWidth = 1;
-            ShadowColor = new Color(42, 42, 42, 42);
-            ShadowSize = 3;
-            ShadowHardness = 50;
-            UnderfillingPivot = 0.5f;
-            ReverseUnderfilling = false;
-            UnderfillingThreshold = 0;
-        }
+    public TransitionHelper(Color? AccentColor = null) 
+    { 
+        _systemAccentColor = AccentColor ?? new Color(128, 128, 128, 128);
     }
+    public bool IsActive => Width > 0 && Height > 0;
+    private readonly Color _systemAccentColor;
+    
+    public byte[] Pixels1 { get; set; } = Array.Empty<byte>();
+    public byte[] Pixels2 { get; set; } = Array.Empty<byte>(); 
+    public byte[] PixelsResult { get; set; } = Array.Empty<byte>();
+    private int[] _labels = Array.Empty<int>();
+    private List<TileSegment> _tileSegmentList = new();
+    private bool[] _selection = Array.Empty<bool>();
+    // Reusable scratch buffers provisioned by EnsureBuffers when the view opens or the
+    // input picture sizes change, reused across recalcs, and released in CleanUp.
+    private float[] _scratchFiltered = Array.Empty<float>();
+    private float[] _scratchGray = Array.Empty<float>();
+    private byte[] _scratchFilteredColor = Array.Empty<byte>();
+    private byte[] _scratchShadowedBg = Array.Empty<byte>();
+    private byte[] _scratchLabelMap = Array.Empty<byte>();    
+
+    private bool _labelsBuilt;
+    private bool _selectionBuilt; 
+    public int Width { get; private set; } = -1;
+    public int Height { get; private set; } = -1; 
+    public TransitionType TypeOfTransition { get; set; } 
+    public TransitionDirection Direction { get; set; }
+    public float Pivot { get; set; } = 0.5f; 
+    public float Hardness { get; set; } = 0.5f;
+    public float Widening { get; set; } = 0f;
+    public float Shift { get; set; } = 0f; 
+    public BricksPipelineRequirements CurrentBricksPipelineRequirements { get; set; }
+        = BricksPipelineRequirements.RequiresAnalysis;
+    public bool ReversePivot { get; set; } = false;
+    public bool InvertGrayscale { get; set; } = false;
+    public bool SliceCornerTiles { get; set; } = false;
+    public bool ProtectEdges { get; set; } = true;
+    public int MarkerCount { get; set; } = 42;
+    public int MarkerRadius { get; set; } = 5;
+    public float GridFitAngle { get; set; } = 0f;
+    public SegmentationMethod SegmentationMethod { get; set; } = SegmentationMethod.Felzenszwalb;
+    public int FelzenszwalbMinSize { get; set; } = 50;
+    public float FelzenszwalbScale { get; set; } = 100f;
+    public int SlicSegmentCount { get; set; } = 250;
+    public float SlicCompactness { get; set; } = 10f;
+    public int QuickshiftMaxDist { get; set; } = 10;
+    public float QuickshiftRatio { get; set; } = 1f;
+    public FilterType SelectedFilter { get; set; } = FilterType.Gaussian;
+    public float BilateralSigma { get; set; } = 30f;
+    public float GaussianSigma { get; set; } = 1f; 
+    public float UnderfillingPivot { get; set; } = 0.5f;
+    public bool ReverseUnderfilling { get; set; } = false;
+    public int UnderfillingThreshold { get; set; } = 0; 
+    public Color EdgeColor { get; set; } = new Color(255, 255, 255, 128);
+    public EdgeBlendMode BlendMode { get; set; } = EdgeBlendMode.Multiply;
+    public int EdgeWidth { get; set; } = 1;
+    public Color ShadowColor { get; set; } = new Color(42, 42, 42, 42);
+    public int ShadowSize { get; set; } = 3;
+    public int ShadowHardness { get; set; } = 50; 
+    public event EventHandler? RecalculationCompleted; 
+    public void Mix()
+    {
+        if (!IsActive)
+            return;
+
+        if (TypeOfTransition == TransitionType.Smooth)
+            MixSmooth(Pixels1, Pixels2, PixelsResult);
+        else
+            MixBricks(Pixels1, Pixels2, PixelsResult);
+    } 
+
+    //public void SetUp()
+    //{
+    //    _labels = new int[INIT_SIZE * INIT_SIZE];
+    //    _tileSegmentList = new List<TileSegment>();
+    //    _selection = new bool[INIT_SIZE * INIT_SIZE]; 
+    //    // Release the reusable scratch buffers so their memory can be reclaimed while the
+    //    // view is closed.
+    //    _scratchFiltered = new float[INIT_SIZE * INIT_SIZE];
+    //    _scratchGray = new float[INIT_SIZE * INIT_SIZE];
+    //    _scratchFilteredColor = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
+    //    _scratchShadowedBg = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
+    //    _scratchLabelMap = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP]; 
+//
+    //    Width = INIT_SIZE;
+    //    Height = INIT_SIZE; 
+    //    Pixels1 = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
+    //    Pixels2 = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
+    //    PixelsResult = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP]; 
+//
+    //    IsActive = true;
+    //}
+
+    public void CleanUp()
+    {
+        _labels = Array.Empty<int>();
+        _tileSegmentList = new List<TileSegment>();
+        _selection = Array.Empty<bool>();
+
+        _scratchFiltered = Array.Empty<float>();
+        _scratchGray = Array.Empty<float>();
+        _scratchFilteredColor = Array.Empty<byte>();
+        _scratchShadowedBg = Array.Empty<byte>();
+        _scratchLabelMap = Array.Empty<byte>();
+        
+        _labelsBuilt = false;
+        _selectionBuilt = false; 
+
+        Width = -1;
+        Height = -1; 
+
+        Pixels1 = Array.Empty<byte>();
+        Pixels2 = Array.Empty<byte>();
+        PixelsResult = Array.Empty<byte>();
+
+        Direction = TransitionDirection.Top;
+        Pivot = 0.5f; 
+        Hardness = 0.5f;
+        Widening = 0f; 
+        MarkerCount = 42; 
+        MarkerRadius = 5;
+        GridFitAngle = 0f;
+        ReversePivot = false;
+        SliceCornerTiles = false;
+        ProtectEdges = true;
+        SegmentationMethod = SegmentationMethod.Felzenszwalb;
+        FelzenszwalbMinSize = 50;
+        FelzenszwalbScale = 100f;
+        SlicSegmentCount = 250;
+        SlicCompactness = 10f;
+        QuickshiftMaxDist = 10;
+        QuickshiftRatio = 1f;
+        SelectedFilter = FilterType.BoxBlur;
+        BilateralSigma = 30f;
+        GaussianSigma = 1f;
+        EdgeColor = new Color(0, 0, 0, 128);
+        BlendMode = EdgeBlendMode.Multiply;
+        EdgeWidth = 1;
+        ShadowColor = new Color(42, 42, 42, 42);
+        ShadowSize = 3;
+        ShadowHardness = 50;
+        UnderfillingPivot = 0.5f;
+        ReverseUnderfilling = false;
+        UnderfillingThreshold = 0;
+    }
+ 
 }

--- a/TgaBuilderLib/Transitions/TransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.cs
@@ -1,25 +1,25 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using TgaBuilderLib.Abstraction;
 
-namespace TgaBuilderLib.Transitions; 
+namespace TgaBuilderLib.Transitions;
 public partial class TransitionHelper : ITransitionHelper
-{ 
-    private const int TRANSITIONS_BPP = 4; // Always BGRA32 
+{
+    private const int TRANSITIONS_BPP = 4; // Always BGRA32
     private const int INIT_SIZE = 64;
 
 
-    public TransitionHelper(Color? AccentColor = null) 
-    { 
+    public TransitionHelper(Color? AccentColor = null)
+    {
         _systemAccentColor = AccentColor ?? new Color(128, 128, 128, 128);
     }
     public bool IsActive => Width > 0 && Height > 0;
     private readonly Color _systemAccentColor;
-    
+
     public byte[] Pixels1 { get; set; } = Array.Empty<byte>();
-    public byte[] Pixels2 { get; set; } = Array.Empty<byte>(); 
+    public byte[] Pixels2 { get; set; } = Array.Empty<byte>();
     public byte[] PixelsResult { get; set; } = Array.Empty<byte>();
     private int[] _labels = Array.Empty<int>();
     private List<TileSegment> _tileSegmentList = new();
@@ -30,18 +30,24 @@ public partial class TransitionHelper : ITransitionHelper
     private float[] _scratchGray = Array.Empty<float>();
     private byte[] _scratchFilteredColor = Array.Empty<byte>();
     private byte[] _scratchShadowedBg = Array.Empty<byte>();
-    private byte[] _scratchLabelMap = Array.Empty<byte>();    
+    private byte[] _scratchLabelMap = Array.Empty<byte>();
+    // Per-pixel Chebyshev distance to the nearest opposite-selection pixel, precomputed once
+    // per selection change and reused by both shadow and edge drawing passes.
+    private int[] _edgeDist = Array.Empty<int>();
 
     private bool _labelsBuilt;
-    private bool _selectionBuilt; 
+    private bool _selectionBuilt;
+    // _edgeDist depends only on the selection, so it is recomputed only when the selection
+    // changes (set false after BuildSelection); drawing-only recalcs reuse it.
+    private bool _edgeDistValid;
     public int Width { get; private set; } = -1;
-    public int Height { get; private set; } = -1; 
-    public TransitionType TypeOfTransition { get; set; } 
+    public int Height { get; private set; } = -1;
+    public TransitionType TypeOfTransition { get; set; }
     public TransitionDirection Direction { get; set; }
-    public float Pivot { get; set; } = 0.5f; 
+    public float Pivot { get; set; } = 0.5f;
     public float Hardness { get; set; } = 0.5f;
     public float Widening { get; set; } = 0f;
-    public float Shift { get; set; } = 0f; 
+    public float Shift { get; set; } = 0f;
     public BricksPipelineRequirements CurrentBricksPipelineRequirements { get; set; }
         = BricksPipelineRequirements.RequiresAnalysis;
     public bool ReversePivot { get; set; } = false;
@@ -60,17 +66,17 @@ public partial class TransitionHelper : ITransitionHelper
     public float QuickshiftRatio { get; set; } = 1f;
     public FilterType SelectedFilter { get; set; } = FilterType.Gaussian;
     public float BilateralSigma { get; set; } = 30f;
-    public float GaussianSigma { get; set; } = 1f; 
+    public float GaussianSigma { get; set; } = 1f;
     public float UnderfillingPivot { get; set; } = 0.5f;
     public bool ReverseUnderfilling { get; set; } = false;
-    public int UnderfillingThreshold { get; set; } = 0; 
+    public int UnderfillingThreshold { get; set; } = 0;
     public Color EdgeColor { get; set; } = new Color(255, 255, 255, 128);
     public EdgeBlendMode BlendMode { get; set; } = EdgeBlendMode.Multiply;
     public int EdgeWidth { get; set; } = 1;
     public Color ShadowColor { get; set; } = new Color(42, 42, 42, 42);
     public int ShadowSize { get; set; } = 3;
-    public int ShadowHardness { get; set; } = 50; 
-    public event EventHandler? RecalculationCompleted; 
+    public int ShadowHardness { get; set; } = 50;
+    public event EventHandler? RecalculationCompleted;
     public void Mix()
     {
         if (!IsActive)
@@ -80,26 +86,26 @@ public partial class TransitionHelper : ITransitionHelper
             MixSmooth(Pixels1, Pixels2, PixelsResult);
         else
             MixBricks(Pixels1, Pixels2, PixelsResult);
-    } 
+    }
 
     //public void SetUp()
     //{
     //    _labels = new int[INIT_SIZE * INIT_SIZE];
     //    _tileSegmentList = new List<TileSegment>();
-    //    _selection = new bool[INIT_SIZE * INIT_SIZE]; 
+    //    _selection = new bool[INIT_SIZE * INIT_SIZE];
     //    // Release the reusable scratch buffers so their memory can be reclaimed while the
     //    // view is closed.
     //    _scratchFiltered = new float[INIT_SIZE * INIT_SIZE];
     //    _scratchGray = new float[INIT_SIZE * INIT_SIZE];
     //    _scratchFilteredColor = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
     //    _scratchShadowedBg = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
-    //    _scratchLabelMap = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP]; 
+    //    _scratchLabelMap = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
 //
     //    Width = INIT_SIZE;
-    //    Height = INIT_SIZE; 
+    //    Height = INIT_SIZE;
     //    Pixels1 = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
     //    Pixels2 = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
-    //    PixelsResult = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP]; 
+    //    PixelsResult = new byte[INIT_SIZE * INIT_SIZE * TRANSITIONS_BPP];
 //
     //    IsActive = true;
     //}
@@ -115,22 +121,24 @@ public partial class TransitionHelper : ITransitionHelper
         _scratchFilteredColor = Array.Empty<byte>();
         _scratchShadowedBg = Array.Empty<byte>();
         _scratchLabelMap = Array.Empty<byte>();
-        
+        _edgeDist = Array.Empty<int>();
+
         _labelsBuilt = false;
-        _selectionBuilt = false; 
+        _selectionBuilt = false;
+        _edgeDistValid = false;
 
         Width = -1;
-        Height = -1; 
+        Height = -1;
 
         Pixels1 = Array.Empty<byte>();
         Pixels2 = Array.Empty<byte>();
         PixelsResult = Array.Empty<byte>();
 
         Direction = TransitionDirection.Top;
-        Pivot = 0.5f; 
+        Pivot = 0.5f;
         Hardness = 0.5f;
-        Widening = 0f; 
-        MarkerCount = 42; 
+        Widening = 0f;
+        MarkerCount = 42;
         MarkerRadius = 5;
         GridFitAngle = 0f;
         ReversePivot = false;
@@ -156,5 +164,5 @@ public partial class TransitionHelper : ITransitionHelper
         ReverseUnderfilling = false;
         UnderfillingThreshold = 0;
     }
- 
+
 }

--- a/TgaBuilderLib/Transitions/TransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.cs
@@ -25,17 +25,17 @@ namespace TgaBuilderLib.Transitions
         public byte[] PixelsResult { get; set; }
 
 
-        private int[] _labels = Array.Empty<int>();
+        private int[] _labels = new int[64 * 64];
         private List<TileSegment> _tileSegmentList = new();
-        private bool[] _selection = Array.Empty<bool>();
+        private bool[] _selection = new bool[64 * 64];
 
         // Reusable scratch buffers provisioned by EnsureBuffers when the view opens or the
         // input picture sizes change, reused across recalcs, and released in CleanUp.
-        private float[] _scratchFiltered = Array.Empty<float>();
-        private float[] _scratchGray = Array.Empty<float>();
-        private byte[] _scratchFilteredColor = Array.Empty<byte>();
-        private byte[] _scratchShadowedBg = Array.Empty<byte>();
-        private byte[] _scratchLabelMap = Array.Empty<byte>();
+        private float[] _scratchFiltered = new float[64 * 64];
+        private float[] _scratchGray = new float[64 * 64];
+        private byte[] _scratchFilteredColor = new byte[64 * 64 * TRANSITIONS_BPP];
+        private byte[] _scratchShadowedBg = new byte[64 * 64 * TRANSITIONS_BPP];
+        private byte[] _scratchLabelMap = new byte[64 * 64 * TRANSITIONS_BPP];
 
         private int _provisionedWidth;
         private int _provisionedHeight;
@@ -135,17 +135,17 @@ namespace TgaBuilderLib.Transitions
 
         public void CleanUp()
         {
-            _labels = Array.Empty<int>();
+            _labels = new int[64 * 64];
             _tileSegmentList = new List<TileSegment>();
-            _selection = Array.Empty<bool>();
+            _selection = new bool[64 * 64];
 
             // Release the reusable scratch buffers so their memory can be reclaimed while the
             // view is closed.
-            _scratchFiltered = Array.Empty<float>();
-            _scratchGray = Array.Empty<float>();
-            _scratchFilteredColor = Array.Empty<byte>();
-            _scratchShadowedBg = Array.Empty<byte>();
-            _scratchLabelMap = Array.Empty<byte>();
+            _scratchFiltered = new float[64 * 64];
+            _scratchGray = new float[64 * 64];
+            _scratchFilteredColor = new byte[64 * 64 * TRANSITIONS_BPP];
+            _scratchShadowedBg = new byte[64 * 64 * TRANSITIONS_BPP];
+            _scratchLabelMap = new byte[64 * 64 * TRANSITIONS_BPP];
 
             _provisionedWidth = 0;
             _provisionedHeight = 0;

--- a/TgaBuilderLib/Transitions/TransitionsHelper.Buffers.cs
+++ b/TgaBuilderLib/Transitions/TransitionsHelper.Buffers.cs
@@ -1,0 +1,37 @@
+namespace TgaBuilderLib.Transitions;
+
+public partial class TransitionHelper
+{
+    /// <summary>Provisions the reusable buffer set for the given input picture size. Called when the
+    /// transitions view opens and whenever the input picture dimensions change. Cheap no-op
+    /// when the size is unchanged, so callers may invoke it freely.</summary>
+    public void EnsureBuffers(int width, int height)
+    {
+        int n = width * height; 
+
+        if (width == Width
+            && height == Width
+            && _scratchFiltered.Length == n)
+            return; 
+
+        int n4 = n * TRANSITIONS_BPP; 
+
+        Pixels1 = new byte[n4];
+        Pixels2 = new byte[n4];
+        PixelsResult = new byte[n4]; 
+
+        _labels = new int[n];
+        _selection = new bool[n]; 
+        _scratchFiltered = new float[n];
+        _scratchGray = new float[n];
+        _scratchFilteredColor = new byte[n4];
+        _scratchShadowedBg = new byte[n4];
+        _scratchLabelMap = new byte[n4]; 
+
+        Width = width;
+        Height = height; 
+
+        _labelsBuilt = false;
+        _selectionBuilt = false;
+    } 
+}

--- a/TgaBuilderLib/Transitions/TransitionsHelper.Buffers.cs
+++ b/TgaBuilderLib/Transitions/TransitionsHelper.Buffers.cs
@@ -10,28 +10,30 @@ public partial class TransitionHelper
         int n = width * height; 
 
         if (width == Width
-            && height == Width
+            && height == Height
             && _scratchFiltered.Length == n)
-            return; 
+            return;
 
-        int n4 = n * TRANSITIONS_BPP; 
+        int n4 = n * TRANSITIONS_BPP;
 
         Pixels1 = new byte[n4];
         Pixels2 = new byte[n4];
-        PixelsResult = new byte[n4]; 
+        PixelsResult = new byte[n4];
 
         _labels = new int[n];
-        _selection = new bool[n]; 
+        _selection = new bool[n];
         _scratchFiltered = new float[n];
         _scratchGray = new float[n];
         _scratchFilteredColor = new byte[n4];
         _scratchShadowedBg = new byte[n4];
-        _scratchLabelMap = new byte[n4]; 
+        _scratchLabelMap = new byte[n4];
+        _edgeDist = new int[n];
 
         Width = width;
-        Height = height; 
+        Height = height;
 
         _labelsBuilt = false;
         _selectionBuilt = false;
-    } 
+        _edgeDistValid = false;
+    }
 }

--- a/TgaBuilderLib/Transitions/TransitionsHelper.Buffers.cs
+++ b/TgaBuilderLib/Transitions/TransitionsHelper.Buffers.cs
@@ -2,12 +2,17 @@ namespace TgaBuilderLib.Transitions;
 
 public partial class TransitionHelper
 {
-    /// <summary>Provisions the reusable buffer set for the given input picture size. Called when the
+    /// <summary>
+    /// Provisions the reusable buffer set for the given input picture size. Called when the
     /// transitions view opens and whenever the input picture dimensions change. Cheap no-op
-    /// when the size is unchanged, so callers may invoke it freely.</summary>
+    /// when the size is unchanged, so callers may invoke it freely.
+    /// </summary>
     public void EnsureBuffers(int width, int height)
     {
-        int n = width * height; 
+        if (width <= 0 || height <= 0)
+            throw new ArgumentException("Width and height must be positive integers.");
+
+        int n = width * height;
 
         if (width == Width
             && height == Height

--- a/TgaBuilderLib/ViewModel/Transitions/TransitionInViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/TransitionInViewModel.cs
@@ -181,67 +181,79 @@ public class TransitionInViewModel : ThrottledViewModelBase
     public void LoadImage1(IWriteableBitmap bitmap)
     {
         Image1 = PrepareAndResizeImage(bitmap);
-        _transitionHelper.Pixels1 = ExtractPixels(Image1);
-    
+
         InitTextVisible = false;
         _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresAnalysis;
-    
+
+        // Provision buffers for the new dimensions before copying pixels into them.
         UpdateHelperDimensionsAndResult(Image1);
-    
+        _transitionHelper.Pixels1 = CopyPixelsInto(Image1, _transitionHelper.Pixels1);
+
         if (AreDimensionsDifferent(Image1, Image2))
         {
             Image2 = ImageInResize(Image2, Image1.PixelWidth, Image1.PixelHeight);
-           _transitionHelper.Pixels2 = ExtractPixels(Image2);
+            _transitionHelper.Pixels2 = CopyPixelsInto(Image2, _transitionHelper.Pixels2);
         }
-    
+
         _ = TriggerRecalculation();
     }
-    
+
     public void LoadImage2(IWriteableBitmap bitmap)
     {
         Image2 = PrepareAndResizeImage(bitmap);
-        _transitionHelper.Pixels2 = ExtractPixels(Image2);
-    
+
         InitTextVisible = false;
         _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresDrawing;
-    
+
+        // Provision buffers for the new dimensions before copying pixels into them.
         UpdateHelperDimensionsAndResult(Image2);
-    
+        _transitionHelper.Pixels2 = CopyPixelsInto(Image2, _transitionHelper.Pixels2);
+
         if (AreDimensionsDifferent(Image1, Image2))
         {
             Image1 = ImageInResize(Image1, Image2.PixelWidth, Image2.PixelHeight);
-            _transitionHelper.Pixels1 = ExtractPixels(Image1);
+            _transitionHelper.Pixels1 = CopyPixelsInto(Image1, _transitionHelper.Pixels1);
             _transitionHelper.CurrentBricksPipelineRequirements = BricksPipelineRequirements.RequiresAnalysis;
         }
 
         _ = TriggerRecalculation();
     }
-    
+
     private IWriteableBitmap PrepareAndResizeImage(IWriteableBitmap bitmap)
     {
         var imageIn = bitmap.HasAlpha
             ? _mediaFactory.CloneBitmap(bitmap)
             : _bitmapOperations.ConvertRGB24ToBGRA32(bitmap);
-    
+
         return ImageInResize(imageIn);
     }
-    
-    private byte[] ExtractPixels(IWriteableBitmap image)
+
+    // Copies the image pixels into the helper's reusable buffer. Once EnsureBuffers has run for
+    // the current dimensions the target is correctly sized and reused in place; the fresh-array
+    // fallback only guards against an unexpected size mismatch.
+    private byte[] CopyPixelsInto(IWriteableBitmap image, byte[] target)
     {
-        // Todo: Let helper prepare buffers instead of copying pixels here
-        var pixels = new byte[image.PixelWidth * image.PixelHeight * TRANSITIONS_BPP];
-        image.CopyPixels(pixels, image.PixelWidth * TRANSITIONS_BPP, 0);
-        return pixels;
+        int stride = image.PixelWidth * TRANSITIONS_BPP;
+        int needed = stride * image.PixelHeight;
+
+        if (target.Length != needed)
+            target = new byte[needed];
+
+        image.CopyPixels(target, stride, 0);
+        return target;
     }
-    
+
     private void UpdateHelperDimensionsAndResult(IWriteableBitmap referenceImage)
     {
         _transitionHelper.Width = referenceImage.PixelWidth;
         _transitionHelper.Height = referenceImage.PixelHeight;
-    
+
+        // Provision the reusable buffer set for the new input picture size.
+        _transitionHelper.EnsureBuffers(referenceImage.PixelWidth, referenceImage.PixelHeight);
+
         TransitionOutVM.ResultImage = _mediaFactory.CreateEmptyBitmap(
-            referenceImage.PixelWidth, 
-            referenceImage.PixelHeight, 
+            referenceImage.PixelWidth,
+            referenceImage.PixelHeight,
             true);
     }
     
@@ -290,8 +302,14 @@ public class TransitionInViewModel : ThrottledViewModelBase
 
     private void ConfigureTransitionHelper()
     {
+        // EdgeColor/ShadowColor are consumed only in the drawing stage, so a color change must not
+        // force a full re-analysis. Pin the pipeline to the drawing stage (mirrors EdgeViewModel /
+        // ShadowViewModel).
+        _transitionHelper.CurrentBricksPipelineRequirements
+            = BricksPipelineRequirements.RequiresDrawing;
+
         _transitionHelper.EdgeColor = EdgeColor;
-        _transitionHelper.ShadowColor = ShadowColor;        
+        _transitionHelper.ShadowColor = ShadowColor;
     }
 
     protected override async Task TriggerRecalculation()

--- a/TgaBuilderLib/ViewModel/Transitions/TransitionInViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/TransitionInViewModel.cs
@@ -153,6 +153,10 @@ public class TransitionInViewModel : ThrottledViewModelBase
     private void DoColorPicking(int x, int y, int imageNum, bool pickShadowColor)
     {
         var sampledColor = _bitmapOperations.GetPixelBrush(imageNum == 1 ? Image1 : Image2, x, y);
+
+        _transitionHelper.CurrentBricksPipelineRequirements
+            = BricksPipelineRequirements.RequiresDrawing;
+
         if (pickShadowColor)
             ShadowColor = sampledColor;
         else
@@ -245,9 +249,6 @@ public class TransitionInViewModel : ThrottledViewModelBase
 
     private void UpdateHelperDimensionsAndResult(IWriteableBitmap referenceImage)
     {
-        _transitionHelper.Width = referenceImage.PixelWidth;
-        _transitionHelper.Height = referenceImage.PixelHeight;
-
         // Provision the reusable buffer set for the new input picture size.
         _transitionHelper.EnsureBuffers(referenceImage.PixelWidth, referenceImage.PixelHeight);
 
@@ -302,12 +303,6 @@ public class TransitionInViewModel : ThrottledViewModelBase
 
     private void ConfigureTransitionHelper()
     {
-        // EdgeColor/ShadowColor are consumed only in the drawing stage, so a color change must not
-        // force a full re-analysis. Pin the pipeline to the drawing stage (mirrors EdgeViewModel /
-        // ShadowViewModel).
-        _transitionHelper.CurrentBricksPipelineRequirements
-            = BricksPipelineRequirements.RequiresDrawing;
-
         _transitionHelper.EdgeColor = EdgeColor;
         _transitionHelper.ShadowColor = ShadowColor;
     }

--- a/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
@@ -147,6 +147,7 @@ public class TransitionOutViewModel : ThrottledViewModelBase
 
     private void UpdateLabelMapImage()
     {
+        // mapData is the helper's reused label-map buffer (no per-call allocation).
         byte[] mapData = _transitionHelper.GetLabelMap();
 
         int mapW = ResultImage?.PixelWidth ?? 0;
@@ -155,13 +156,15 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         if (mapData.Length == 0 || mapW == 0 || mapH == 0)
             return;
 
-        var labelBmp = _mediaFactory.CreateEmptyBitmap(mapW, mapH, true);
-        labelBmp.WritePixels(
-            new PixelRect(0, 0, mapW, mapH),
-            mapData,
-            mapW * 4);
+        var labelBmp = LabelMapImage;
+        if (labelBmp is null || labelBmp.PixelWidth != mapW || labelBmp.PixelHeight != mapH)
+        {
+            labelBmp = _mediaFactory.CreateEmptyBitmap(mapW, mapH, true);
+            LabelMapImage = labelBmp;
+        }
 
-        LabelMapImage = labelBmp;
+        using var frameBuffer = labelBmp.GetLocker(requiresRefresh: true);
+        Marshal.Copy(mapData, 0, frameBuffer.BackBuffer, mapW * mapH * TRANSITIONS_BPP);
     }
 
     private void RequestNewIndicatorMapImage(int x, int y)
@@ -171,6 +174,7 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         if (label == 0)
             return;
 
+        // mapData is the helper's reused label-map buffer (no per-call allocation).
         byte[] mapData = _transitionHelper.GetTileIndicator(label);
 
         int mapW = ResultImage?.PixelWidth ?? 0;
@@ -179,13 +183,15 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         if (mapData.Length == 0 || mapW == 0 || mapH == 0)
             return;
 
-        var indicatorBmp = _mediaFactory.CreateEmptyBitmap(mapW, mapH, true);
-        indicatorBmp.WritePixels(
-            new PixelRect(0, 0, mapW, mapH),
-            mapData,
-            mapW * 4);
+        var indicatorBmp = IndicatorMapImage;
+        if (indicatorBmp is null || indicatorBmp.PixelWidth != mapW || indicatorBmp.PixelHeight != mapH)
+        {
+            indicatorBmp = _mediaFactory.CreateEmptyBitmap(mapW, mapH, true);
+            IndicatorMapImage = indicatorBmp;
+        }
 
-        IndicatorMapImage = indicatorBmp;
+        using var frameBuffer = indicatorBmp.GetLocker(requiresRefresh: true);
+        Marshal.Copy(mapData, 0, frameBuffer.BackBuffer, mapW * mapH * TRANSITIONS_BPP);
     }
 
     private void SetExplicitTileVisibility(int x, int y)

--- a/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
@@ -149,30 +149,32 @@ public class TransitionOutViewModel : ThrottledViewModelBase
 
     private void UpdateLabelMapImage()
     {
+        if (ResultImage.PixelWidth <= 0 || ResultImage.PixelHeight <= 0)
+            return;
+
         // mapData is the helper's reused label-map buffer (no per-call allocation).
         byte[] mapData = _transitionHelper.GetLabelMap();
 
-        int mapW = ResultImage?.PixelWidth ?? 0;
-        int mapH = ResultImage?.PixelHeight ?? 0;
-
-        if (mapData.Length == 0 || mapW == 0 || mapH == 0)
-            return;
-
         var labelBmp = LabelMapImage;
-        if (labelBmp is null || labelBmp.PixelWidth != mapW || labelBmp.PixelHeight != mapH)
+        if (labelBmp is null 
+            || labelBmp.PixelWidth != ResultImage.PixelWidth 
+            || labelBmp.PixelHeight != ResultImage.PixelHeight)
         {
-            labelBmp = _mediaFactory.CreateEmptyBitmap(mapW, mapH, true);
+            labelBmp = _mediaFactory.CreateEmptyBitmap(ResultImage.PixelWidth, ResultImage.PixelHeight, true);
             LabelMapImage = labelBmp;
         }
 
         using var frameBuffer = labelBmp.GetLocker(requiresRefresh: true);
-        Marshal.Copy(mapData, 0, frameBuffer.BackBuffer, mapW * mapH * TRANSITIONS_BPP);
+        Marshal.Copy(mapData, 0, frameBuffer.BackBuffer, ResultImage.PixelWidth * ResultImage.PixelHeight * TRANSITIONS_BPP);
 
         LabelInvalidator?.InvalidateVisual();
     }
 
     private void RequestNewIndicatorMapImage(int x, int y)
     {
+        if (ResultImage.PixelWidth <= 0 || ResultImage.PixelHeight <= 0)
+            return;
+
         int label = _transitionHelper.GetLabelAtPixel(x, y);
 
         if (label == 0)
@@ -181,21 +183,20 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         // mapData is the helper's reused label-map buffer (no per-call allocation).
         byte[] mapData = _transitionHelper.GetTileIndicator(label);
 
-        int mapW = ResultImage?.PixelWidth ?? 0;
-        int mapH = ResultImage?.PixelHeight ?? 0;
-
-        if (mapData.Length == 0 || mapW == 0 || mapH == 0)
+        if (mapData.Length == 0 || ResultImage.PixelWidth <= 0 || ResultImage.PixelHeight <= 0)
             return;
 
         var indicatorBmp = IndicatorMapImage;
-        if (indicatorBmp is null || indicatorBmp.PixelWidth != mapW || indicatorBmp.PixelHeight != mapH)
+        if (indicatorBmp is null 
+            || indicatorBmp.PixelWidth != ResultImage.PixelWidth 
+            || indicatorBmp.PixelHeight != ResultImage.PixelHeight)
         {
-            indicatorBmp = _mediaFactory.CreateEmptyBitmap(mapW, mapH, true);
+            indicatorBmp = _mediaFactory.CreateEmptyBitmap(ResultImage.PixelWidth, ResultImage.PixelHeight, true);
             IndicatorMapImage = indicatorBmp;
         }
 
         using var frameBuffer = indicatorBmp.GetLocker(requiresRefresh: true);
-        Marshal.Copy(mapData, 0, frameBuffer.BackBuffer, mapW * mapH * TRANSITIONS_BPP);
+        Marshal.Copy(mapData, 0, frameBuffer.BackBuffer, ResultImage.PixelWidth * ResultImage.PixelHeight * TRANSITIONS_BPP);
 
         ResultInvalidator?.InvalidateVisual();
     }
@@ -236,6 +237,12 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         InitTextVisible = true;
         _resultImage = _mediaFactory.CreateEmptyBitmap(64, 64, true);
         _labelMapImage = null;
+
+        if (ResultInvalidator is not null)
+            ResultInvalidator = null;
+
+        if (LabelInvalidator is not null) 
+            LabelInvalidator = null;
     }
 
     public void EndMouseInteraction()

--- a/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
@@ -43,7 +43,9 @@ public class TransitionOutViewModel : ThrottledViewModelBase
 
     private bool _initTextVisible = true;
 
-    public IVisualInvalidator? VisualInvalidator { get; set; }
+    public IVisualInvalidator? ResultInvalidator { get; set; }
+
+    public IVisualInvalidator? LabelInvalidator { get; set; }
 
 
 
@@ -165,6 +167,8 @@ public class TransitionOutViewModel : ThrottledViewModelBase
 
         using var frameBuffer = labelBmp.GetLocker(requiresRefresh: true);
         Marshal.Copy(mapData, 0, frameBuffer.BackBuffer, mapW * mapH * TRANSITIONS_BPP);
+
+        LabelInvalidator?.InvalidateVisual();
     }
 
     private void RequestNewIndicatorMapImage(int x, int y)
@@ -192,6 +196,8 @@ public class TransitionOutViewModel : ThrottledViewModelBase
 
         using var frameBuffer = indicatorBmp.GetLocker(requiresRefresh: true);
         Marshal.Copy(mapData, 0, frameBuffer.BackBuffer, mapW * mapH * TRANSITIONS_BPP);
+
+        ResultInvalidator?.InvalidateVisual();
     }
 
     private void SetExplicitTileVisibility(int x, int y)
@@ -251,7 +257,7 @@ public class TransitionOutViewModel : ThrottledViewModelBase
             destination: ResLockedFrameBuffer.BackBuffer, 
             length: _transitionHelper.PixelsResult.Length);
 
-        VisualInvalidator?.InvalidateVisual();
+        ResultInvalidator?.InvalidateVisual();
 
         if (_transitionHelper.TypeOfTransition == TransitionType.Bricks)
             UpdateLabelMapImage();

--- a/TgaBuilderLib/ViewModel/Views/MainViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/MainViewModel.cs
@@ -445,11 +445,13 @@ namespace TgaBuilderLib.ViewModel
                 return;
 
             var transitionView = _getViewCallback(ViewIndex.Transition);
-            if (transitionView.DataContext is not TransitionViewModel)
+            if (transitionView.DataContext is not TransitionViewModel transitionViewModel)
                 return;
 
             transitionView.Topmost = true;
             IsTransitionViewOpen = true;
+
+            transitionViewModel.OnViewOpened();
 
             await transitionView.ShowAsync();
         }

--- a/TgaBuilderLib/ViewModel/Views/MainViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/MainViewModel.cs
@@ -451,8 +451,6 @@ namespace TgaBuilderLib.ViewModel
             transitionView.Topmost = true;
             IsTransitionViewOpen = true;
 
-            transitionViewModel.OnViewOpened();
-
             await transitionView.ShowAsync();
         }
 

--- a/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
@@ -140,15 +140,6 @@ public class TransitionViewModel : ThrottledViewModelBase
         TransitionInVM.Mix();
     }
 
-
-    // Provisions the reusable buffer set when the transitions view is opened. At this point no
-    // images are loaded yet, so the helper is still at its default size; loading an image
-    // re-provisions for the real input picture size via EnsureBuffers.
-    public void OnViewOpened()
-    {
-        _transitionHelper.EnsureBuffers(_transitionHelper.Width, _transitionHelper.Height);
-    }
-
     private void MarkFinished()
     {
         TransitionInVM.ResetImages();

--- a/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
@@ -139,6 +139,14 @@ public class TransitionViewModel : ThrottledViewModelBase
     }
 
 
+    // Provisions the reusable buffer set when the transitions view is opened. At this point no
+    // images are loaded yet, so the helper is still at its default size; loading an image
+    // re-provisions for the real input picture size via EnsureBuffers.
+    public void OnViewOpened()
+    {
+        _transitionHelper.EnsureBuffers(_transitionHelper.Width, _transitionHelper.Height);
+    }
+
     private void MarkFinished()
     {
         TransitionInVM.ResetImages();

--- a/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Views/TransitionViewModel.cs
@@ -40,6 +40,8 @@ public class TransitionViewModel : ThrottledViewModelBase
         TransitionOutVM = TransitionInVM.TransitionOutVM;
 
         IsBrickMode = true;
+
+        _transitionHelper.EnsureBuffers(64, 64);
     }
 
     // =====================================================================


### PR DESCRIPTION
Provision a reusable buffer set on TransitionHelper (EnsureBuffers) when the
transitions view opens or the input picture sizes change, reuse it across
recalculations, and release it on view close (CleanUp). This eliminates the
~6-7 MB of large-array allocation churn (much of it on the LOH) that previously
occurred on every throttled recalc during slider/eyedropper interaction.

- Add owned exact-size scratch buffers (filtered/gray/filteredColor/shadowedBg/
  labelMap) plus reuse of Pixels1/2/Result and _labels/_selection. Keeping the
  exact Width*Height(*4) length preserves all .Length-based validation and the
  OutVM Marshal.Copy, so no length-tracking refactor is needed.
- Pipeline methods (MixSmooth/MixBricks/BricksAnalyze/BuildSelection/BricksDraw)
  now write into the provided/cached buffers instead of allocating. Mandatory
  clears added where a stage only writes part of a buffer (filter output borders,
  labels pre-segmentation, selection).
- Track first-use via _labelsBuilt/_selectionBuilt flags since pre-provisioned
  arrays are no longer zero-length.
- Reuse pixel buffers on image load (copy-into-existing) and reorder load so
  dimensions/EnsureBuffers precede the pixel copy.
- Remove dead allocations in MixBricks (immediately-overwritten arrays).
- Set RequiresDrawing for edge/shadow color changes so a color pick no longer
  forces a full re-segmentation.
- GetLabelMap/GetTileIndicator drop the throwaway label copy and reuse an owned
  buffer; OutVM uploads via the locker + Marshal.Copy path, reusing the bitmap
  when its size is unchanged.

https://claude.ai/code/session_01HELZEX813Aysfbd7MMuh6R