### PR TITLE
PSD writer: compute converged image internally and add multi-layer service

### DIFF
--- a/TgaBuilderAvaloniaUi/App.DI.axaml.cs
+++ b/TgaBuilderAvaloniaUi/App.DI.axaml.cs
@@ -21,6 +21,7 @@ using TgaBuilderLib.ViewModel.Views;
 using Avalonia;
 using Avalonia.Controls;
 using TgaBuilderLib.Krita;
+using TgaBuilderLib.Psd;
 
 namespace TgaBuilderAvaloniaUi
 {
@@ -83,6 +84,7 @@ namespace TgaBuilderAvaloniaUi
         private void AddCoreServicesToProvider(IServiceCollection services)
         {
             services.AddSingleton<IKraFileService, KraFileService>();
+            services.AddSingleton<IPsdFileService, PsdFileService>();
             services.AddSingleton<ITrngDecrypter, TrngDecrypter>();
             services.AddSingleton<IBitmapBytesIO, BitmapBytesIO>();
 

--- a/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.ToPsd.cs
+++ b/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.ToPsd.cs
@@ -29,17 +29,27 @@ public partial class BitmapBytesIO
         if (LoadedBytes is null)
             throw new InvalidOperationException("No image data loaded. Please load an image first.");
 
-        var bitmap = _mediaFactory.CreateBitmapFromRaw(
-            LoadedWidth, LoadedHeight, hasAlpha: true, LoadedBytes, LoadedWidth * 4);
+        // The layer must own its pixels: LoadedBytes is a pooled buffer that
+        // ClearLoadedData() returns to the pool, so copy the active slice into a
+        // dedicated array. This keeps accumulated layers valid across writes.
+        var ownedBytes = new byte[ActualDataLength];
+        Array.Copy(LoadedBytes, ownedBytes, ActualDataLength);
 
-        var psd = new PsdFile();
+        var bitmap = _mediaFactory.CreateBitmapFromRaw(
+            LoadedWidth, LoadedHeight, hasAlpha: true, ownedBytes, LoadedWidth * 4);
+
+        _psdFileService.OutputPath = filePath;
 
         var layerInfo = new PsdLayerInfo(
             bitmap: bitmap,
             rect: new PixelRect(0, 0, bitmap.PixelWidth, bitmap.PixelHeight),
             name: "Background");
 
-        psd.Save(filePath, bitmap, Enumerable.Empty<PsdLayerInfo>().Append(layerInfo));
+        _psdFileService.LayerInfos.Add(layerInfo);
+
+        _psdFileService.WriteFile();
+
+        _psdFileService.CleanUp();
     }
 
     public IWriteableBitmap ConvertRGB24ToBGRA32(IWriteableBitmap sourceBitmap)

--- a/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.ToPsd.cs
+++ b/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.ToPsd.cs
@@ -47,9 +47,18 @@ public partial class BitmapBytesIO
 
         _psdFileService.LayerInfos.Add(layerInfo);
 
-        _psdFileService.WriteFile();
-
-        _psdFileService.CleanUp();
+        try
+        {
+            _psdFileService.WriteFile();
+        }
+        catch(Exception)
+        {
+            throw;
+        }
+        finally
+        {
+            _psdFileService.CleanUp();
+        }
     }
 
     public IWriteableBitmap ConvertRGB24ToBGRA32(IWriteableBitmap sourceBitmap)

--- a/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.cs
+++ b/TgaBuilderLib/BitmapBytesIO/BitmapBytesIO.cs
@@ -3,6 +3,7 @@ using TgaBuilderLib.Abstraction;
 using TgaBuilderLib.Enums;
 using TgaBuilderLib.FileHandling;
 using TgaBuilderLib.Krita;
+using TgaBuilderLib.Psd;
 
 namespace TgaBuilderLib.BitmapBytesIO
 {
@@ -10,10 +11,12 @@ namespace TgaBuilderLib.BitmapBytesIO
     {
         public BitmapBytesIO(
             IMediaFactory mediaFactory,
-            IKraFileService kraFileService)
+            IKraFileService kraFileService,
+            IPsdFileService psdFileService)
         {
             _mediaFactory = mediaFactory ?? throw new ArgumentNullException(nameof(mediaFactory));
             _kritaFileService = kraFileService ?? throw new ArgumentNullException(nameof(kraFileService));
+            _psdFileService = psdFileService ?? throw new ArgumentNullException(nameof(psdFileService));
         }
 
         private const int MAX_SIZE = 32768;
@@ -24,6 +27,8 @@ namespace TgaBuilderLib.BitmapBytesIO
         private readonly IMediaFactory _mediaFactory;
 
         private readonly IKraFileService _kritaFileService;
+
+        private readonly IPsdFileService _psdFileService;
 
         public ResultStatus ResultInfo { get; private set; } = ResultStatus.Success;
 

--- a/TgaBuilderLib/Psd/IPsdFileService.cs
+++ b/TgaBuilderLib/Psd/IPsdFileService.cs
@@ -1,0 +1,18 @@
+namespace TgaBuilderLib.Psd;
+
+/// <summary>
+/// Accumulates layers and writes them to a PSD file. Mirrors
+/// <see cref="Krita.IKraFileService"/> so the PSD and Krita save paths share the
+/// same shape: add one or more layers, then <see cref="WriteFile"/>.
+/// </summary>
+public interface IPsdFileService
+{
+    string OutputPath { get; set; }
+
+    /// <summary>Layers to write, ordered from bottom to top.</summary>
+    List<PsdLayerInfo> LayerInfos { get; }
+
+    void WriteFile();
+
+    void CleanUp();
+}

--- a/TgaBuilderLib/Psd/PsdFile.Save.cs
+++ b/TgaBuilderLib/Psd/PsdFile.Save.cs
@@ -10,50 +10,47 @@ namespace TgaBuilderLib.Psd;
 public partial class PsdFile
 {
     /// <summary>
-    /// Saves a 32-bit RGBA PSD file containing a merged background image and a set of layers.
+    /// Saves a 32-bit RGBA PSD file containing the given layers.
+    /// The merged/composite background image is computed from the layers.
     /// </summary>
     /// <param name="filename">Destination file path.</param>
-    /// <param name="background">
-    /// Merged/composite background bitmap in BGRA 32-bit format.
-    /// Its dimensions define the PSD canvas size.
-    /// </param>
     /// <param name="layerInfos">
     /// Layers to include in the PSD, listed from bottom to top.
     /// Each layer bitmap must be in BGRA 32-bit format.
     /// </param>
-    public void Save(string filename, IReadableBitmap background, IEnumerable<PsdLayerInfo> layerInfos)
+    public void Save(string filename, IEnumerable<PsdLayerInfo> layerInfos)
     {
         using var stream = new FileStream(filename, FileMode.Create, FileAccess.Write);
-        Save(stream, background, layerInfos);
+        Save(stream, layerInfos);
     }
 
     /// <summary>
     /// Writes a 32-bit RGBA PSD file to the given stream.
+    /// The merged/composite background image is computed from the layers.
     /// </summary>
     /// <param name="stream">Output stream (must be writable and seekable).</param>
-    /// <param name="background">
-    /// Merged/composite background bitmap in BGRA 32-bit format.
-    /// Its dimensions define the PSD canvas size.
-    /// </param>
     /// <param name="layerInfos">
     /// Layers to include in the PSD, listed from bottom to top.
     /// Each layer bitmap must be in BGRA 32-bit format.
     /// </param>
-    public void Save(Stream stream, IReadableBitmap background, IEnumerable<PsdLayerInfo> layerInfos)
+    public void Save(Stream stream, IEnumerable<PsdLayerInfo> layerInfos)
     {
+        var infoList = layerInfos.ToList();
+
+        if (infoList.Count == 0)
+            throw new ArgumentException("Error, list of Layer Infos cannot be empty");
+
         Version = 1;
 
-        Columns = background.PixelWidth;
-        Rows = background.PixelHeight;
+        // The canvas spans the bounding box of all layer rectangles.
+        Columns = infoList.Max(info => info.Rect.Right);
+        Rows = infoList.Max(info => info.Rect.Bottom);
 
         Depth = 8;
         Channels = 4; // RGBA
 
         var writer = new BinaryReverseWriter(stream);
-        var layerList = layerInfos.Select(info => new Layer(info, this)).ToList();
-
-        if (!layerList.Any())
-            throw new ArgumentException("Error, list of Layer Infos cannot be empty");
+        var layerList = infoList.Select(info => new Layer(info, this)).ToList();
 
         // ── Header ──────────────────────────────────────────────────────────
         writer.Write("8BPS".ToCharArray());  // PSD signature
@@ -126,8 +123,9 @@ public partial class PsdFile
         writer.Write((short)ImageCompression.Rle);
 
         int pixelCount = Columns * Rows;
-        var bgra = new byte[pixelCount * 4];
-        background.CopyPixels(new PixelRect(0, 0, Columns, Rows), bgra, Columns * 4, 0);
+
+        // The merged image is the straight-alpha composite of all layers.
+        var bgra = CompositeLayers(infoList, Columns, Rows);
 
         // PSD stores channels as separate planar arrays: R, G, B, A
         // BGRA layout: [0]=B  [1]=G  [2]=R  [3]=A
@@ -180,5 +178,78 @@ public partial class PsdFile
         {
             writer.Write(compressedChannelData[ch]);
         }
+    }
+
+    /// <summary>
+    /// Composites the layers (index 0 = bottom) onto a transparent
+    /// <paramref name="width"/> x <paramref name="height"/> canvas using the
+    /// straight-alpha "source over" operator. Each layer is placed at its
+    /// <see cref="PsdLayerInfo.Rect"/> offset, its alpha is scaled by
+    /// <see cref="PsdLayerInfo.Opacity"/>, and invisible layers are skipped.
+    /// Layer bitmaps are expected to be BGRA 32-bit. Blend modes other than
+    /// Normal are not applied to the merged result.
+    /// </summary>
+    private static byte[] CompositeLayers(IReadOnlyList<PsdLayerInfo> layers, int width, int height)
+    {
+        var canvas = new byte[width * height * 4]; // BGRA, fully transparent
+
+        foreach (var info in layers)
+        {
+            if (!info.Visible)
+                continue;
+
+            int layerW = info.Rect.Width;
+            int layerH = info.Rect.Height;
+            int offsetX = info.Rect.X;
+            int offsetY = info.Rect.Y;
+            float layerOpacity = info.Opacity / 255f;
+
+            var src = new byte[layerW * layerH * 4];
+            info.Bitmap.CopyPixels(new PixelRect(0, 0, layerW, layerH), src, layerW * 4, 0);
+
+            for (int y = 0; y < layerH; y++)
+            {
+                int dy = y + offsetY;
+                if (dy < 0 || dy >= height)
+                    continue;
+
+                int sRow = y * layerW * 4;
+                int dRow = dy * width * 4;
+
+                for (int x = 0; x < layerW; x++)
+                {
+                    int dx = x + offsetX;
+                    if (dx < 0 || dx >= width)
+                        continue;
+
+                    int sPix = sRow + x * 4;
+                    int dPix = dRow + dx * 4;
+
+                    float sourceAlpha = (src[sPix + 3] / 255f) * layerOpacity;
+
+                    if (sourceAlpha <= 0f)
+                        continue;
+
+                    float destinationAlpha = canvas[dPix + 3] / 255f;
+
+                    float oa = sourceAlpha + destinationAlpha * (1f - sourceAlpha);
+
+                    if (oa <= 0f)
+                        continue;
+
+                    for (int c = 0; c < 3; c++)
+                    {
+                        float sc = src[sPix + c];
+                        float dc = canvas[dPix + c];
+                        float oc = (sc * sourceAlpha + dc * destinationAlpha * (1f - sourceAlpha)) / oa;
+                        canvas[dPix + c] = (byte)Math.Clamp(oc + 0.5f, 0f, 255f);
+                    }
+
+                    canvas[dPix + 3] = (byte)Math.Clamp(oa * 255f + 0.5f, 0f, 255f);
+                }
+            }
+        }
+
+        return canvas;
     }
 }

--- a/TgaBuilderLib/Psd/PsdFile.Save.cs
+++ b/TgaBuilderLib/Psd/PsdFile.Save.cs
@@ -43,6 +43,7 @@ public partial class PsdFile
         Version = 1;
 
         // The canvas spans the bounding box of all layer rectangles.
+        // Smaller Images will put to the top-left corner of the canvas.
         Columns = infoList.Max(info => info.Rect.Right);
         Rows = infoList.Max(info => info.Rect.Bottom);
 

--- a/TgaBuilderLib/Psd/PsdFileService.cs
+++ b/TgaBuilderLib/Psd/PsdFileService.cs
@@ -1,0 +1,25 @@
+namespace TgaBuilderLib.Psd;
+
+public class PsdFileService : IPsdFileService
+{
+    public string OutputPath { get; set; } = "output.psd";
+
+    public List<PsdLayerInfo> LayerInfos { get; } = new();
+
+    public void WriteFile()
+    {
+        if (LayerInfos.Count == 0)
+            throw new InvalidOperationException("No layers to write.");
+
+        var dir = Path.GetDirectoryName(OutputPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        new PsdFile().Save(OutputPath, LayerInfos);
+    }
+
+    public void CleanUp()
+    {
+        LayerInfos.Clear();
+    }
+}

--- a/TgaBuilderWpfUi/App.DI.xaml.cs
+++ b/TgaBuilderWpfUi/App.DI.xaml.cs
@@ -20,6 +20,7 @@ using TgaBuilderWpfUi.Wrappers;
 using Application = System.Windows.Application;
 using Wpf.Ui.Appearance;
 using TgaBuilderLib.Krita;
+using TgaBuilderLib.Psd;
 
 namespace TgaBuilderWpfUi
 {
@@ -75,6 +76,7 @@ namespace TgaBuilderWpfUi
         private void AddCoreServicesToProvider(IServiceCollection services)
         {
             services.AddSingleton<IKraFileService, KraFileService>();
+            services.AddSingleton<IPsdFileService, PsdFileService>();
             services.AddSingleton<ITrngDecrypter, TrngDecrypter>();
             services.AddSingleton<IBitmapBytesIO, BitmapBytesIO>();
 


### PR DESCRIPTION
PsdFile.Save no longer takes a separate pre-flattened background bitmap.
It now accepts only the layer list and computes the merged/composite image
itself via a straight-alpha source-over CompositeLayers helper (mirroring the
Krita writer), honoring per-layer offset, opacity and visibility. Canvas size
is derived from the bounding box of the layer rectangles.

Add IPsdFileService/PsdFileService that accumulate PsdLayerInfo layers and write
them, mirroring IKraFileService. Inject it into BitmapBytesIO and route WritePsd
through it; each layer now owns a private copy of its pixels so multiple layers
can be accumulated safely. Register the service in the Avalonia and WPF DI.