### PR TITLE
Add manual tile move and rotate functionality to brick transitions

### DIFF
--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml
@@ -210,7 +210,8 @@
                                 PointerMoved="ResultImage_PointerMoved"
                                 PointerEntered="ResultImage_PointerEntered"
                                 PointerExited="ResultImage_PointerExited"
-                                PointerPressed="ResultImage_PointerPressed" />
+                                PointerPressed="ResultImage_PointerPressed"
+                                PointerWheelChanged="ResultImage_PointerWheelChanged" />
                             <Image
                                 x:Name="IndicatorImage"
                                 RenderOptions.BitmapInterpolationMode="None"

--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml
@@ -211,6 +211,7 @@
                                 PointerEntered="ResultImage_PointerEntered"
                                 PointerExited="ResultImage_PointerExited"
                                 PointerPressed="ResultImage_PointerPressed"
+                                PointerReleased="ResultImage_PointerReleased"
                                 PointerWheelChanged="ResultImage_PointerWheelChanged" />
                             <Image
                                 x:Name="IndicatorImage"

--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
@@ -185,6 +185,8 @@ namespace TgaBuilderAvaloniaUi.View
 
             if (e.GetCurrentPoint(ResultImage).Properties.IsLeftButtonPressed)
                 tpvm.ManualPointerDragCommand.Execute((X: x, Y: y));
+            else if (tpvm.IsTileRotateMode && e.Pointer.Captured == ResultImage)
+                e.Pointer.Capture(null);
         }
 
         private void ResultImage_PointerEntered(object? sender, PointerEventArgs e)
@@ -211,7 +213,14 @@ namespace TgaBuilderAvaloniaUi.View
                 return;
 
             tpvm.IsIndicatorMapVisible = false;
-            tpvm.EndManipulationCommand.Execute(null);
+
+            if (tpvm.IsTileMoveRotateMode || tpvm.IsTileRotateMode)
+            {
+                if (tpvm.IsTileRotateMode && e.Pointer.Captured == ResultImage)
+                    return;
+
+                tpvm.EndManipulationCommand.Execute(null);
+            }
         }
 
         private void ResultImage_PointerPressed(object? sender, PointerPressedEventArgs e)
@@ -229,6 +238,20 @@ namespace TgaBuilderAvaloniaUi.View
 
             var currentPosition = e.GetPosition(ResultImage);
             tpvm.ManualPointerDownCommand.Execute((X: (int)currentPosition.X, Y: (int)currentPosition.Y));
+
+            if (tpvm.IsTileRotateMode)
+                e.Pointer.Capture(ResultImage);
+        }
+
+        private void ResultImage_PointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (DataContext is not TransitionViewModel vm)
+                return;
+
+            var tpvm = vm.TransitionOutVM;
+
+            if (tpvm.IsTileRotateMode && e.Pointer.Captured == ResultImage)
+                e.Pointer.Capture(null);
         }
 
         private void ResultImage_PointerWheelChanged(object? sender, PointerWheelEventArgs e)

--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
@@ -174,21 +174,17 @@ namespace TgaBuilderAvaloniaUi.View
 
             var tpvm = vm.TransitionOutVM;
 
-            if (!tpvm.IsExplicitTileVisibilityDrawMode && !tpvm.IsExplicitTileVisibilityEraseMode)
+            if (!tpvm.IsAnyManualMode)
                 return;
 
-            if (tpvm.RequestLabelIndicatorCommand is ICommand requestLabelIndicatorCommand)
-            {
-                var currentPosition = e.GetPosition(ResultImage);
-                requestLabelIndicatorCommand.Execute((X: (int)currentPosition.X, Y: (int)currentPosition.Y));
-            }
+            var currentPosition = e.GetPosition(ResultImage);
+            int x = (int)currentPosition.X;
+            int y = (int)currentPosition.Y;
 
-            if (e.GetCurrentPoint(ResultImage).Properties.IsLeftButtonPressed
-                && tpvm.SetExplicitTileVisibilityCommand is ICommand setExplicitTileVisibilityCommand)
-            {
-                var currentPosition = e.GetPosition(ResultImage);
-                setExplicitTileVisibilityCommand.Execute((X: (int)currentPosition.X, Y: (int)currentPosition.Y));
-            }
+            tpvm.RequestLabelIndicatorCommand.Execute((X: x, Y: y));
+
+            if (e.GetCurrentPoint(ResultImage).Properties.IsLeftButtonPressed)
+                tpvm.ManualPointerDragCommand.Execute((X: x, Y: y));
         }
 
         private void ResultImage_PointerEntered(object? sender, PointerEventArgs e)
@@ -198,7 +194,7 @@ namespace TgaBuilderAvaloniaUi.View
 
             var tpvm = vm.TransitionOutVM;
 
-            if (!tpvm.IsExplicitTileVisibilityDrawMode && !tpvm.IsExplicitTileVisibilityEraseMode)
+            if (!tpvm.IsAnyManualMode)
                 return;
 
             tpvm.IsIndicatorMapVisible = true;
@@ -211,10 +207,11 @@ namespace TgaBuilderAvaloniaUi.View
 
             var tpvm = vm.TransitionOutVM;
 
-            if (!tpvm.IsExplicitTileVisibilityDrawMode && !tpvm.IsExplicitTileVisibilityEraseMode)
+            if (!tpvm.IsAnyManualMode)
                 return;
 
             tpvm.IsIndicatorMapVisible = false;
+            tpvm.EndManipulationCommand.Execute(null);
         }
 
         private void ResultImage_PointerPressed(object? sender, PointerPressedEventArgs e)
@@ -224,15 +221,35 @@ namespace TgaBuilderAvaloniaUi.View
 
             var tpvm = vm.TransitionOutVM;
 
-            if (!tpvm.IsExplicitTileVisibilityDrawMode && !tpvm.IsExplicitTileVisibilityEraseMode)
+            if (!tpvm.IsAnyManualMode)
                 return;
 
-            if (e.GetCurrentPoint(ResultImage).Properties.IsLeftButtonPressed
-                && tpvm.SetExplicitTileVisibilityCommand is ICommand setExplicitTileVisibilityCommand)
-            {
-                var currentPosition = e.GetPosition(ResultImage);
-                setExplicitTileVisibilityCommand.Execute((X: (int)currentPosition.X, Y: (int)currentPosition.Y));
-            }
+            if (!e.GetCurrentPoint(ResultImage).Properties.IsLeftButtonPressed)
+                return;
+
+            var currentPosition = e.GetPosition(ResultImage);
+            tpvm.ManualPointerDownCommand.Execute((X: (int)currentPosition.X, Y: (int)currentPosition.Y));
+        }
+
+        private void ResultImage_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
+        {
+            if (DataContext is not TransitionViewModel vm)
+                return;
+
+            var tpvm = vm.TransitionOutVM;
+
+            if (!tpvm.IsTileMoveRotateMode)
+                return;
+
+            int notches = e.Delta.Y > 0 ? 1 : (e.Delta.Y < 0 ? -1 : 0);
+            if (notches == 0)
+                return;
+
+            var currentPosition = e.GetPosition(ResultImage);
+            tpvm.RotateActiveTileCommand.Execute((X: (int)currentPosition.X, Y: (int)currentPosition.Y, Notches: notches));
+
+            // Prevent the wheel from also scrolling/zooming the surrounding UI while rotating.
+            e.Handled = true;
         }
     }
 }

--- a/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindow.axaml.cs
@@ -238,7 +238,7 @@ namespace TgaBuilderAvaloniaUi.View
 
             var tpvm = vm.TransitionOutVM;
 
-            if (!tpvm.IsTileMoveRotateMode)
+            if (!tpvm.IsWheelRotationMode)
                 return;
 
             int notches = e.Delta.Y > 0 ? 1 : (e.Delta.Y < 0 ? -1 : 0);

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowManualUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowManualUserControl.axaml
@@ -15,43 +15,55 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-        <StackPanel
+        <WrapPanel
             DataContext="{Binding TransitionOutVM}"
             Orientation="Horizontal"
-                    Spacing="8"
                     Margin="0,6,8,8">
             <elements:IconToggleButton
                 Classes="outlined"
                 VerticalAlignment="Center"
+                Margin="0,0,8,8"
                 MinHeight="36"
                 MinWidth="36"
                 Icon="{StaticResource pen_white}"
-                ap:MouseOverInfoAP.InfoText="Enable manual drawing of visible tiles"
+                ap:MouseOverInfoAP.InfoText="Enable manual drawing of visible tiles. The mouse wheel rotates the last tile set visible."
                 IsChecked="{Binding IsExplicitTileVisibilityDrawMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <elements:IconToggleButton
                 x:Name="ProtectEdgesToggleButton"
                 Classes="outlined"
                 VerticalAlignment="Center"
+                Margin="0,0,8,8"
                 MinHeight="36"
                 MinWidth="36"
                 Icon="{StaticResource eraser}"
-                ap:MouseOverInfoAP.InfoText="Enable manual erasing of visible tiles"
+                ap:MouseOverInfoAP.InfoText="Enable manual erasing of visible tiles. Erasing a moved/rotated tile restores its original position and rotation."
                 IsChecked="{Binding IsExplicitTileVisibilityEraseMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <elements:IconToggleButton
                 Classes="outlined"
                 VerticalAlignment="Center"
+                Margin="0,0,8,8"
                 MinHeight="36"
                 MinWidth="36"
                 Icon="{StaticResource arrow_move}"
                 ap:MouseOverInfoAP.InfoText="Move tiles by dragging and rotate them with the mouse wheel"
                 IsChecked="{Binding IsTileMoveRotateMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <elements:IconToggleButton
+                Classes="outlined"
+                VerticalAlignment="Center"
+                Margin="0,0,8,8"
+                MinHeight="36"
+                MinWidth="36"
+                Icon="{StaticResource arrow_rotate_counterclockwise}"
+                ap:MouseOverInfoAP.InfoText="Rotate a tile: click it and drag to spin it; the mouse wheel fine-tunes the last rotated tile"
+                IsChecked="{Binding IsTileRotateMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <elements:IconButton
                 Classes="outlined"
                 VerticalAlignment="Center"
+                Margin="0,0,8,8"
                 MinHeight="36"
                 MinWidth="36"
                 Icon="{StaticResource backspace}"
                 ap:MouseOverInfoAP.InfoText="Reset all manual adjustments (visibility, moves and rotations)"
                 Command="{Binding ResetExplicitVisibilityCommand}" />
-        </StackPanel>
+        </WrapPanel>
 </UserControl>

--- a/TgaBuilderAvaloniaUi/View/TransitionWindowManualUserControl.axaml
+++ b/TgaBuilderAvaloniaUi/View/TransitionWindowManualUserControl.axaml
@@ -37,13 +37,21 @@
                 Icon="{StaticResource eraser}"
                 ap:MouseOverInfoAP.InfoText="Enable manual erasing of visible tiles"
                 IsChecked="{Binding IsExplicitTileVisibilityEraseMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <elements:IconToggleButton
+                Classes="outlined"
+                VerticalAlignment="Center"
+                MinHeight="36"
+                MinWidth="36"
+                Icon="{StaticResource arrow_move}"
+                ap:MouseOverInfoAP.InfoText="Move tiles by dragging and rotate them with the mouse wheel"
+                IsChecked="{Binding IsTileMoveRotateMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <elements:IconButton
                 Classes="outlined"
                 VerticalAlignment="Center"
                 MinHeight="36"
                 MinWidth="36"
                 Icon="{StaticResource backspace}"
-                ap:MouseOverInfoAP.InfoText="Reset Explicit Visibility"
+                ap:MouseOverInfoAP.InfoText="Reset all manual adjustments (visibility, moves and rotations)"
                 Command="{Binding ResetExplicitVisibilityCommand}" />
         </StackPanel>
 </UserControl>

--- a/TgaBuilderLib/Transitions/ITransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/ITransitionHelper.cs
@@ -73,7 +73,9 @@ namespace TgaBuilderLib.Transitions
         // Manual single-tile move/rotate operations.
         int PickManipulableTileAt(int x, int y);
         (int X, int Y) GetTileOffset(int tileLabel);
+        float GetTileTwist(int tileLabel);
         bool MoveTile(int tileLabel, int offsetX, int offsetY);
+        bool SetTileTwist(int tileLabel, float angleDegrees);
         bool RotateTileBy(int tileLabel, float deltaDegrees);
 
         // Builds the bottom-to-top layer stack for a multi-layer export of the

--- a/TgaBuilderLib/Transitions/ITransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/ITransitionHelper.cs
@@ -59,12 +59,22 @@ namespace TgaBuilderLib.Transitions
         bool ReverseUnderfilling { get; set; }
         int UnderfillingThreshold { get; set; }
 
+        // Label of the tile currently being moved/rotated (drawn on top of other manipulated
+        // tiles). 0 means none.
+        int ActiveManipulatedTileLabel { get; set; }
+
         // Methods
         void EnsureBuffers(int width, int height);
         void Mix();
         byte[] GetLabelMap();
         int GetLabelAtPixel(int x, int y);
         byte[] GetTileIndicator(int tileIndex);
+
+        // Manual single-tile move/rotate operations.
+        int PickManipulableTileAt(int x, int y);
+        (int X, int Y) GetTileOffset(int tileLabel);
+        bool MoveTile(int tileLabel, int offsetX, int offsetY);
+        bool RotateTileBy(int tileLabel, float deltaDegrees);
 
         // Builds the bottom-to-top layer stack for a multi-layer export of the
         // current transition (smooth or bricks).

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
@@ -51,6 +51,44 @@ public partial class TransitionHelper
         DrawShadows(bgPixels, selection, _edgeDist, shadowedBg);
 
         DrawResult(tilePixels, selection, _edgeDist, shadowedBg, result);
+
+        // Manually moved/rotated tiles are part of the selection (so they cast shadows and form
+        // the mask correctly), but the base pass above sampled the static tile image at their new
+        // positions, i.e. the wrong content. Repaint their true content from the original source
+        // pixels here, on top of everything, so they overlay any static tiles they now cover.
+        DrawManipulatedTiles(tilePixels, result);
+    }
+
+    // Repaints the user-manipulated tiles over the finished base result. For each tile the source
+    // pixels (the tile's original, un-rotated image data) are copied into their transformed
+    // destination positions computed by BuildSelection. Drawn in list order with the active tile
+    // last, so the tile the user is currently manipulating ends up on top.
+    private void DrawManipulatedTiles(byte[] tilePixels, byte[] result)
+    {
+        if (_manipulatedTiles.Count == 0)
+            return;
+
+        unsafe
+        {
+            fixed (byte* pTile = tilePixels)
+            fixed (byte* pRes = result)
+            {
+                foreach (var tile in _manipulatedTiles)
+                {
+                    int[] dst = tile.DstOffsets;
+                    int[] src = tile.SrcOffsets;
+                    for (int i = 0; i < dst.Length; i++)
+                    {
+                        int d = dst[i] * TRANSITIONS_BPP;
+                        int s = src[i] * TRANSITIONS_BPP;
+                        pRes[d + 0] = pTile[s + 0];
+                        pRes[d + 1] = pTile[s + 1];
+                        pRes[d + 2] = pTile[s + 2];
+                        pRes[d + 3] = pTile[s + 3];
+                    }
+                }
+            }
+        }
     }
 
     // Computes, for every pixel, the Chebyshev (L-infinity) distance to the nearest pixel of

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksDraw.cs
@@ -59,19 +59,29 @@ public partial class TransitionHelper
         DrawManipulatedTiles(tilePixels, result);
     }
 
-    // Repaints the user-manipulated tiles over the finished base result. For each tile the source
-    // pixels (the tile's original, un-rotated image data) are copied into their transformed
-    // destination positions computed by BuildSelection. Drawn in list order with the active tile
-    // last, so the tile the user is currently manipulating ends up on top.
+    // Repaints the user-manipulated tiles over the finished base result. For each destination pixel
+    // the true source color (the tile's original, un-rotated image data) is blended through the
+    // shared BlendSelectedPixel path, so moved/rotated tiles get the same edge tinting (and over the
+    // same shadowed background) as static tiles. Edge proximity uses _edgeDist, which was computed
+    // from the final selection that already includes these footprints. Drawn in list order with the
+    // active tile last, so the tile the user is currently manipulating ends up on top.
     private void DrawManipulatedTiles(byte[] tilePixels, byte[] result)
     {
         if (_manipulatedTiles.Count == 0)
             return;
 
+        int eA = EdgeColor.A ?? 255;
+        int invA = 255 - eA;
+        int eR = EdgeColor.R;
+        int eG = EdgeColor.G;
+        int eB = EdgeColor.B;
+
         unsafe
         {
             fixed (byte* pTile = tilePixels)
             fixed (byte* pRes = result)
+            fixed (byte* pShadowBg = _scratchShadowedBg)
+            fixed (int* pEdgeDist = _edgeDist)
             {
                 foreach (var tile in _manipulatedTiles)
                 {
@@ -79,12 +89,17 @@ public partial class TransitionHelper
                     int[] src = tile.SrcOffsets;
                     for (int i = 0; i < dst.Length; i++)
                     {
-                        int d = dst[i] * TRANSITIONS_BPP;
-                        int s = src[i] * TRANSITIONS_BPP;
-                        pRes[d + 0] = pTile[s + 0];
-                        pRes[d + 1] = pTile[s + 1];
-                        pRes[d + 2] = pTile[s + 2];
-                        pRes[d + 3] = pTile[s + 3];
+                        int d = dst[i];
+                        int s = src[i];
+                        int x = d % Width;
+                        int y = d / Width;
+
+                        BlendSelectedPixel(
+                            pRes, d * TRANSITIONS_BPP,
+                            pTile, s * TRANSITIONS_BPP,
+                            pShadowBg, d * TRANSITIONS_BPP,
+                            x, y, pEdgeDist[d],
+                            eA, invA, eR, eG, eB);
                     }
                 }
             }
@@ -319,112 +334,129 @@ public partial class TransitionHelper
                     for (int x = 0; x < Width; x++)
                     {
                         int pixelIndex = y * Width + x;
+                        if (!selection[pixelIndex])
+                            continue;
+
                         int offset = rowOffset + (x * 4);
 
-                        // 1. Calculate dynamic widths based on proximity to image borders.
-                        int distToBorderX = Math.Min(x, Width - 1 - x);
-                        int distToBorderY = Math.Min(y, Height - 1 - y);
-                        int distToBorder = Math.Min(distToBorderX, distToBorderY);
-
-                        // Dynamic widths drop linearly towards image bounds.
-                        int dynamicEdgeWidth = Math.Min(EdgeWidth, distToBorder);
-                        if (selection[pixelIndex])
-                        {
-                            // Distance to the nearest unselected pixel (precomputed).
-                            int minDist = edgeDist[pixelIndex];
-
-                            // 3. Color the selected tile pixel based on the distance (Edge tint)
-                            if (dynamicEdgeWidth > 0 && minDist <= dynamicEdgeWidth)
-                            {
-                                int weight255 = ((dynamicEdgeWidth - minDist + 1) * 255) / dynamicEdgeWidth;
-                                int invWeight255 = 255 - weight255;
-
-                                // Current channels of the tile pixel
-                                int tB = pTile[offset + 0];
-                                int tG = pTile[offset + 1];
-                                int tR = pTile[offset + 2];
-                                int tA = pTile[offset + 3];
-
-                                int tintedB, tintedG, tintedR;
-
-                                // 1. Application mode for the edge color
-                                switch (BlendMode)
-                                {
-                                    case EdgeBlendMode.Screen: // Multiply negatively
-                                        tintedB = 255 - ((255 - tB) * (255 - eB) / 255);
-                                        tintedG = 255 - ((255 - tG) * (255 - eG) / 255);
-                                        tintedR = 255 - ((255 - tR) * (255 - eR) / 255);
-                                        break;
-
-                                    case EdgeBlendMode.Additive: // Add
-                                        tintedB = Math.Min(255, tB + eB);
-                                        tintedG = Math.Min(255, tG + eG);
-                                        tintedR = Math.Min(255, tR + eR);
-                                        break;
-
-                                    case EdgeBlendMode.Overlay: // Copy into each other
-                                        tintedB = (tB < 128) ? (2 * tB * eB / 255) : (255 - 2 * (255 - tB) * (255 - eB) / 255);
-                                        tintedG = (tG < 128) ? (2 * tG * eG / 255) : (255 - 2 * (255 - tG) * (255 - eG) / 255);
-                                        tintedR = (tR < 128) ? (2 * tR * eR / 255) : (255 - 2 * (255 - tR) * (255 - eR) / 255);
-                                        break;
-
-                                    case EdgeBlendMode.HardLight:
-                                        tintedB = (eB < 128) ? (2 * tB * eB / 255) : (255 - 2 * (255 - tB) * (255 - eB) / 255);
-                                        tintedG = (eG < 128) ? (2 * tG * eG / 255) : (255 - 2 * (255 - tG) * (255 - eG) / 255);
-                                        tintedR = (eR < 128) ? (2 * tR * eR / 255) : (255 - 2 * (255 - tR) * (255 - eR) / 255);
-                                        break;
-
-                                    case EdgeBlendMode.SoftLight:
-                                        tintedB = SoftLightChannel(tB, eB);
-                                        tintedG = SoftLightChannel(tG, eG);
-                                        tintedR = SoftLightChannel(tR, eR);
-                                        break;
-
-                                    case EdgeBlendMode.ColorDodge:
-                                        tintedB = eB == 255 ? 255 : Math.Min(255, (tB * 255) / (255 - eB));
-                                        tintedG = eG == 255 ? 255 : Math.Min(255, (tG * 255) / (255 - eG));
-                                        tintedR = eR == 255 ? 255 : Math.Min(255, (tR * 255) / (255 - eR));
-                                        break;
-
-                                    case EdgeBlendMode.ColorBurn:
-                                        tintedB = eB == 0 ? 0 : Math.Max(0, 255 - ((255 - tB) * 255) / eB);
-                                        tintedG = eG == 0 ? 0 : Math.Max(0, 255 - ((255 - tG) * 255) / eG);
-                                        tintedR = eR == 0 ? 0 : Math.Max(0, 255 - ((255 - tR) * 255) / eR);
-                                        break;
-
-                                    case EdgeBlendMode.Multiply: // Standard: Multiply
-                                    default:
-                                        tintedB = (tB * eB) / 255;
-                                        tintedG = (tG * eG) / 255;
-                                        tintedR = (tR * eR) / 255;
-                                        break;
-                                }
-
-                                // 2. Background influence
-                                // How strongly does the edge color influence the original background?
-                                int maxEdgeB = (tintedB * eA + pShadowBg[offset + 0] * invA) / 255;
-                                int maxEdgeG = (tintedG * eA + pShadowBg[offset + 1] * invA) / 255;
-                                int maxEdgeR = (tintedR * eA + pShadowBg[offset + 2] * invA) / 255;
-                                int maxEdgeAlpha = (tA * eA + pShadowBg[offset + 3] * invA) / 255;
-
-                                // 3. Final gradient blending based on distance to edge
-                                pRes[offset + 0] = (byte)((maxEdgeB * weight255 + tB * invWeight255) / 255);
-                                pRes[offset + 1] = (byte)((maxEdgeG * weight255 + tG * invWeight255) / 255);
-                                pRes[offset + 2] = (byte)((maxEdgeR * weight255 + tR * invWeight255) / 255);
-                                pRes[offset + 3] = (byte)((maxEdgeAlpha * weight255 + tA * invWeight255) / 255);
-                            }
-                            else
-                            {
-                                // Inner pixels or absolute image border pixels: copy original tile.
-                                pRes[offset + 0] = pTile[offset + 0];
-                                pRes[offset + 1] = pTile[offset + 1];
-                                pRes[offset + 2] = pTile[offset + 2];
-                                pRes[offset + 3] = pTile[offset + 3];
-                            }
-                        }
+                        // Selected tile pixel: copy the tile color, tinting it toward EdgeColor near
+                        // the selection boundary. Shared with the manipulated-tile overlay pass so
+                        // both static and moved/rotated tiles get identical edge tinting.
+                        BlendSelectedPixel(
+                            pRes, offset,
+                            pTile, offset,
+                            pShadowBg, offset,
+                            x, y, edgeDist[pixelIndex],
+                            eA, invA, eR, eG, eB);
                     }
                 }
             }
+        }
+    }
+
+    // Writes one selected tile pixel into the result: the tile color, blended toward EdgeColor
+    // (per BlendMode and EdgeWidth) as it approaches the selection boundary, over the shadowed
+    // background. Factored out of DrawResult so the manipulated-tile overlay reuses the exact same
+    // edge tinting. AggressiveInlining keeps DrawResult's per-pixel hot loop allocation/call-free.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private unsafe void BlendSelectedPixel(
+        byte* pRes, int resOffset,
+        byte* pTile, int tileOffset,
+        byte* pShadowBg, int shadowOffset,
+        int x, int y, int minDist,
+        int eA, int invA, int eR, int eG, int eB)
+    {
+        // Dynamic edge width drops linearly towards the image bounds.
+        int distToBorderX = Math.Min(x, Width - 1 - x);
+        int distToBorderY = Math.Min(y, Height - 1 - y);
+        int distToBorder = Math.Min(distToBorderX, distToBorderY);
+        int dynamicEdgeWidth = Math.Min(EdgeWidth, distToBorder);
+
+        if (dynamicEdgeWidth > 0 && minDist <= dynamicEdgeWidth)
+        {
+            int weight255 = ((dynamicEdgeWidth - minDist + 1) * 255) / dynamicEdgeWidth;
+            int invWeight255 = 255 - weight255;
+
+            // Current channels of the tile pixel
+            int tB = pTile[tileOffset + 0];
+            int tG = pTile[tileOffset + 1];
+            int tR = pTile[tileOffset + 2];
+            int tA = pTile[tileOffset + 3];
+
+            int tintedB, tintedG, tintedR;
+
+            // 1. Application mode for the edge color
+            switch (BlendMode)
+            {
+                case EdgeBlendMode.Screen: // Multiply negatively
+                    tintedB = 255 - ((255 - tB) * (255 - eB) / 255);
+                    tintedG = 255 - ((255 - tG) * (255 - eG) / 255);
+                    tintedR = 255 - ((255 - tR) * (255 - eR) / 255);
+                    break;
+
+                case EdgeBlendMode.Additive: // Add
+                    tintedB = Math.Min(255, tB + eB);
+                    tintedG = Math.Min(255, tG + eG);
+                    tintedR = Math.Min(255, tR + eR);
+                    break;
+
+                case EdgeBlendMode.Overlay: // Copy into each other
+                    tintedB = (tB < 128) ? (2 * tB * eB / 255) : (255 - 2 * (255 - tB) * (255 - eB) / 255);
+                    tintedG = (tG < 128) ? (2 * tG * eG / 255) : (255 - 2 * (255 - tG) * (255 - eG) / 255);
+                    tintedR = (tR < 128) ? (2 * tR * eR / 255) : (255 - 2 * (255 - tR) * (255 - eR) / 255);
+                    break;
+
+                case EdgeBlendMode.HardLight:
+                    tintedB = (eB < 128) ? (2 * tB * eB / 255) : (255 - 2 * (255 - tB) * (255 - eB) / 255);
+                    tintedG = (eG < 128) ? (2 * tG * eG / 255) : (255 - 2 * (255 - tG) * (255 - eG) / 255);
+                    tintedR = (eR < 128) ? (2 * tR * eR / 255) : (255 - 2 * (255 - tR) * (255 - eR) / 255);
+                    break;
+
+                case EdgeBlendMode.SoftLight:
+                    tintedB = SoftLightChannel(tB, eB);
+                    tintedG = SoftLightChannel(tG, eG);
+                    tintedR = SoftLightChannel(tR, eR);
+                    break;
+
+                case EdgeBlendMode.ColorDodge:
+                    tintedB = eB == 255 ? 255 : Math.Min(255, (tB * 255) / (255 - eB));
+                    tintedG = eG == 255 ? 255 : Math.Min(255, (tG * 255) / (255 - eG));
+                    tintedR = eR == 255 ? 255 : Math.Min(255, (tR * 255) / (255 - eR));
+                    break;
+
+                case EdgeBlendMode.ColorBurn:
+                    tintedB = eB == 0 ? 0 : Math.Max(0, 255 - ((255 - tB) * 255) / eB);
+                    tintedG = eG == 0 ? 0 : Math.Max(0, 255 - ((255 - tG) * 255) / eG);
+                    tintedR = eR == 0 ? 0 : Math.Max(0, 255 - ((255 - tR) * 255) / eR);
+                    break;
+
+                case EdgeBlendMode.Multiply: // Standard: Multiply
+                default:
+                    tintedB = (tB * eB) / 255;
+                    tintedG = (tG * eG) / 255;
+                    tintedR = (tR * eR) / 255;
+                    break;
+            }
+
+            // 2. Background influence: how strongly the edge color influences the background.
+            int maxEdgeB = (tintedB * eA + pShadowBg[shadowOffset + 0] * invA) / 255;
+            int maxEdgeG = (tintedG * eA + pShadowBg[shadowOffset + 1] * invA) / 255;
+            int maxEdgeR = (tintedR * eA + pShadowBg[shadowOffset + 2] * invA) / 255;
+            int maxEdgeAlpha = (tA * eA + pShadowBg[shadowOffset + 3] * invA) / 255;
+
+            // 3. Final gradient blending based on distance to edge
+            pRes[resOffset + 0] = (byte)((maxEdgeB * weight255 + tB * invWeight255) / 255);
+            pRes[resOffset + 1] = (byte)((maxEdgeG * weight255 + tG * invWeight255) / 255);
+            pRes[resOffset + 2] = (byte)((maxEdgeR * weight255 + tR * invWeight255) / 255);
+            pRes[resOffset + 3] = (byte)((maxEdgeAlpha * weight255 + tA * invWeight255) / 255);
+        }
+        else
+        {
+            // Inner pixels or absolute image border pixels: copy original tile.
+            pRes[resOffset + 0] = pTile[tileOffset + 0];
+            pRes[resOffset + 1] = pTile[tileOffset + 1];
+            pRes[resOffset + 2] = pTile[tileOffset + 2];
+            pRes[resOffset + 3] = pTile[tileOffset + 3];
         }
     }
 

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksLabelMap.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksLabelMap.cs
@@ -11,6 +11,12 @@ public partial class TransitionHelper
 {
     // Creates a colored debug map from label data and stores analysis dimensions.
 
+    // The label map picking and the hover indicator follow manual moves/rotations, so they read
+    // from the current occupancy map once it has been built; before that they fall back to the raw
+    // segmentation. The colored debug map (GetLabelMap) deliberately keeps using _labels.
+    private int[] CurrentLabels =>
+        (_selectionBuilt && _manualLabels.Length == _labels.Length) ? _manualLabels : _labels;
+
     public int GetLabelAtPixel(int x, int y)
     {
         if (x < 0 || x >= Width || y < 0 || y >= Height)
@@ -20,7 +26,7 @@ public partial class TransitionHelper
             return 0;
 
         int index = y * Width + x;
-        return _labels[index];
+        return CurrentLabels[index];
     }
     public byte[] GetLabelMap()
     {
@@ -112,10 +118,14 @@ public partial class TransitionHelper
         // ARGB (same as before)
         uint indicatorColorArgb = (uint)(255 << 24 | r << 16 | g << 8 | b);
 
+        // Highlight the tile at its current location: a moved tile lights up at its new position
+        // and a vacated hole stays empty, reflecting the manual adjustments.
+        int[] sourceLabels = CurrentLabels;
+
         unsafe
         {
             fixed (byte* pDebug = map)
-            fixed (int* pLabels = _labels)
+            fixed (int* pLabels = sourceLabels)
             {
                 for (int y = 0; y < Height; y++)
                 {

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksManual.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksManual.cs
@@ -15,14 +15,24 @@ public partial class TransitionHelper
             throw new ArgumentOutOfRangeException(nameof(tileIndex), "Tile index is out of range.");
 
         int listIndex = tileIndex - 1;
+        var segment = _tileSegmentList[listIndex];
 
-        bool? currentValue = _tileSegmentList[listIndex].ShouldDrawExplicitly;
+        bool? currentValue = segment.ShouldDrawExplicitly;
+        segment.ShouldDrawExplicitly = shouldDraw;
 
-        _tileSegmentList[listIndex].ShouldDrawExplicitly = shouldDraw;
+        bool changed = !currentValue.HasValue || currentValue.Value != shouldDraw;
 
-        if (!currentValue.HasValue || currentValue.Value != shouldDraw)
-            return true; // Visibility changed
-        return false;
+        // Erasing a tile returns it to its original position and orientation: a hidden tile should
+        // not retain a manual move/rotation, so revealing it again starts clean.
+        if (!shouldDraw && (segment.OffsetX != 0 || segment.OffsetY != 0 || segment.TwistAngle != 0f))
+        {
+            segment.OffsetX = 0;
+            segment.OffsetY = 0;
+            segment.TwistAngle = 0f;
+            changed = true;
+        }
+
+        return changed;
     }
 
     // Picks the tile that can be manually moved/rotated at the given result-image pixel. Uses the
@@ -71,6 +81,40 @@ public partial class TransitionHelper
         bool changed = segment.OffsetX != offsetX || segment.OffsetY != offsetY;
         segment.OffsetX = offsetX;
         segment.OffsetY = offsetY;
+
+        if (segment.ShouldDrawExplicitly != true)
+        {
+            segment.ShouldDrawExplicitly = true;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    // Current manual rotation (in degrees) of the given tile. Used by the view model to anchor a
+    // drag-to-rotate gesture to the tile's existing angle.
+    public float GetTileTwist(int tileLabel)
+    {
+        int listIndex = tileLabel - 1;
+        if (listIndex < 0 || listIndex >= _tileSegmentList.Count)
+            return 0f;
+
+        return _tileSegmentList[listIndex].TwistAngle;
+    }
+
+    // Sets a tile's absolute manual rotation (in degrees) about its centroid via its TwistAngle
+    // property. A rotated tile is always made visible. Returns true if anything changed. Used by the
+    // drag-to-rotate gesture; the mouse wheel uses the incremental RotateTileBy.
+    public bool SetTileTwist(int tileLabel, float angleDegrees)
+    {
+        int listIndex = tileLabel - 1;
+        if (listIndex < 0 || listIndex >= _tileSegmentList.Count)
+            return false;
+
+        var segment = _tileSegmentList[listIndex];
+
+        bool changed = segment.TwistAngle != angleDegrees;
+        segment.TwistAngle = angleDegrees;
 
         if (segment.ShouldDrawExplicitly != true)
         {

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksManual.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksManual.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -24,9 +25,120 @@ public partial class TransitionHelper
         return false;
     }
 
+    // Picks the tile that can be manually moved/rotated at the given result-image pixel. Uses the
+    // current occupancy map, so a moved tile is picked at its new position and a vacated hole reads
+    // as background. Returns 0 (none) for background/holes and — when ProtectEdges is set — for
+    // tiles touching an image border, which must stay put to keep the transition seamless.
+    public int PickManipulableTileAt(int x, int y)
+    {
+        int label = GetLabelAtPixel(x, y);
+        if (label == 0)
+            return 0;
+
+        int listIndex = label - 1;
+        if (listIndex < 0 || listIndex >= _tileSegmentList.Count)
+            return 0;
+
+        if (ProtectEdges && DoesTileTouchAnyEdge(_tileSegmentList[listIndex].PixelOffsets))
+            return 0;
+
+        return label;
+    }
+
+    // Current manual translation (in result-image pixels) of the given tile. Used by the view model
+    // to anchor a drag to the tile's existing offset.
+    public (int X, int Y) GetTileOffset(int tileLabel)
+    {
+        int listIndex = tileLabel - 1;
+        if (listIndex < 0 || listIndex >= _tileSegmentList.Count)
+            return (0, 0);
+
+        var segment = _tileSegmentList[listIndex];
+        return (segment.OffsetX, segment.OffsetY);
+    }
+
+    // Sets a tile's absolute manual translation (in result-image pixels) via its Offset properties.
+    // A moved tile is always made visible (ShouldDrawExplicitly = true), even if it was hidden
+    // before. Returns true if anything changed.
+    public bool MoveTile(int tileLabel, int offsetX, int offsetY)
+    {
+        int listIndex = tileLabel - 1;
+        if (listIndex < 0 || listIndex >= _tileSegmentList.Count)
+            return false;
+
+        var segment = _tileSegmentList[listIndex];
+
+        bool changed = segment.OffsetX != offsetX || segment.OffsetY != offsetY;
+        segment.OffsetX = offsetX;
+        segment.OffsetY = offsetY;
+
+        if (segment.ShouldDrawExplicitly != true)
+        {
+            segment.ShouldDrawExplicitly = true;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    // Adds a delta (in degrees) to a tile's manual rotation about its centroid via its TwistAngle
+    // property. A rotated tile is always made visible. Returns true if anything changed.
+    public bool RotateTileBy(int tileLabel, float deltaDegrees)
+    {
+        int listIndex = tileLabel - 1;
+        if (listIndex < 0 || listIndex >= _tileSegmentList.Count)
+            return false;
+
+        var segment = _tileSegmentList[listIndex];
+
+        bool changed = false;
+        if (deltaDegrees != 0f)
+        {
+            segment.TwistAngle += deltaDegrees;
+            changed = true;
+        }
+
+        if (segment.ShouldDrawExplicitly != true)
+        {
+            segment.ShouldDrawExplicitly = true;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    // Returns everything to the state before any manual interaction: visibility overrides cleared
+    // and all moves/rotations undone.
     public void ResetAllExplicitTileVisibility()
     {
         foreach (var segment in _tileSegmentList)
+        {
             segment.ShouldDrawExplicitly = null;
+            segment.OffsetX = 0;
+            segment.OffsetY = 0;
+            segment.TwistAngle = 0f;
+        }
+
+        _manipulatedTiles.Clear();
+        ActiveManipulatedTileLabel = 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool DoesTileTouchAnyEdge(List<int> pixelOffsets)
+    {
+        int width = Width;
+        int lastX = width - 1;
+        int lastY = Height - 1;
+
+        foreach (int offset in pixelOffsets)
+        {
+            int y = offset / width;
+            int x = offset % width;
+
+            if (x == 0 || y == 0 || x == lastX || y == lastY)
+                return true;
+        }
+
+        return false;
     }
 }

--- a/TgaBuilderLib/Transitions/TransitionHelper.BricksSelection.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.BricksSelection.cs
@@ -23,8 +23,16 @@ public partial class TransitionHelper
         // pixels to true (it never resets them), so stale trues from a previous recalc must not
         // leak through.
         bool[] selection = _selection;
-        Array.Clear(selection, 0, Width * Height);
+        int pixelCount = Width * Height;
+        Array.Clear(selection, 0, pixelCount);
         int labelCount = tileSegments.Count;
+
+        // Rebuild the "current occupancy" label map. It starts as the untouched segmentation (so
+        // every tile stays pickable, including hidden ones) and is then patched by
+        // ApplyManipulatedTiles to punch holes at vacated positions and stamp relocated footprints.
+        if (_manualLabels.Length == pixelCount)
+            Array.Copy(_labels, _manualLabels, pixelCount);
+        _manipulatedTiles.Clear();
 
         TransitionDirection mode = Direction;
         bool reversePivot = ReversePivot;
@@ -59,6 +67,18 @@ public partial class TransitionHelper
 
             float v = ComputeFocus(Direction, segment.CentroidX, segment.CentroidY, Widening, Shift);
             bool shouldDraw = segment.ShouldDrawExplicitly ?? (ReversePivot ? (v <= Pivot) : (v >= Pivot));
+
+            // Manually moved/rotated tiles are placed explicitly by the user. They bypass the
+            // edge-protection, corner-slicing and underfilling cuts and are rasterized after the
+            // static selection is finalized (see ApplyManipulatedTiles), so they always land on
+            // top and are never eaten into.
+            bool isManipulated = segment.OffsetX != 0 || segment.OffsetY != 0 || segment.TwistAngle != 0f;
+            if (isManipulated)
+            {
+                if (shouldDraw)
+                    _manipulatedTiles.Add(ComputeManipulatedFootprint(labelID, segment));
+                continue;
+            }
 
             ReadOnlySpan<int> tileOffsets = CollectionsMarshal.AsSpan(pixelOffsets);
 
@@ -104,6 +124,157 @@ public partial class TransitionHelper
 
         if (UnderfillingThreshold > 0)
             SubstractUnderfilled(selection, tilePixels);
+
+        ApplyManipulatedTiles(tileSegments, selection);
+    }
+
+    // Computes a manipulated tile's footprint by inverse mapping. For every destination pixel in
+    // the transformed bounding box it finds the source pixel it samples from (R(-twist) around the
+    // centroid, minus the offset) and keeps it only when that source pixel actually belongs to the
+    // tile. Using inverse mapping avoids the holes a forward rotation would leave and yields one
+    // unique source per destination, so no destination is ever written twice.
+    private ManipulatedTile ComputeManipulatedFootprint(int label, TileSegment segment)
+    {
+        int width = Width;
+        int height = Height;
+        var pixelOffsets = segment.PixelOffsets;
+
+        // Original axis-aligned bounding box of the tile.
+        int minX = int.MaxValue, minY = int.MaxValue, maxX = int.MinValue, maxY = int.MinValue;
+        foreach (int off in pixelOffsets)
+        {
+            int x = off % width;
+            int y = off / width;
+            if (x < minX) minX = x;
+            if (x > maxX) maxX = x;
+            if (y < minY) minY = y;
+            if (y > maxY) maxY = y;
+        }
+
+        // CentroidX/Y are normalized (0..1); multiplying by the dimension restores the exact
+        // pixel-space centroid the tile is rotated around.
+        double cx = segment.CentroidX * width;
+        double cy = segment.CentroidY * height;
+        int ox = segment.OffsetX;
+        int oy = segment.OffsetY;
+
+        double ang = segment.TwistAngle * Math.PI / 180.0;
+        double cos = Math.Cos(ang);
+        double sin = Math.Sin(ang);
+
+        // Forward-transform the four corners to bound the destination region, then clamp to image.
+        int[] cornerX = { minX, maxX, minX, maxX };
+        int[] cornerY = { minY, minY, maxY, maxY };
+        int dMinX = int.MaxValue, dMinY = int.MaxValue, dMaxX = int.MinValue, dMaxY = int.MinValue;
+        for (int c = 0; c < 4; c++)
+        {
+            double rx = cos * (cornerX[c] - cx) - sin * (cornerY[c] - cy) + cx + ox;
+            double ry = sin * (cornerX[c] - cx) + cos * (cornerY[c] - cy) + cy + oy;
+            int lo = (int)Math.Floor(rx);
+            int hi = (int)Math.Ceiling(rx);
+            if (lo < dMinX) dMinX = lo;
+            if (hi > dMaxX) dMaxX = hi;
+            lo = (int)Math.Floor(ry);
+            hi = (int)Math.Ceiling(ry);
+            if (lo < dMinY) dMinY = lo;
+            if (hi > dMaxY) dMaxY = hi;
+        }
+
+        // Expand by 1px so nearest-neighbor rounding at the rotated edges can never clip the tile,
+        // then clamp to the image (out-of-image parts are dropped by the per-pixel bounds check).
+        dMinX -= 1; dMinY -= 1; dMaxX += 1; dMaxY += 1;
+        if (dMinX < 0) dMinX = 0;
+        if (dMinY < 0) dMinY = 0;
+        if (dMaxX > width - 1) dMaxX = width - 1;
+        if (dMaxY > height - 1) dMaxY = height - 1;
+
+        var dst = new List<int>();
+        var src = new List<int>();
+
+        for (int dy = dMinY; dy <= dMaxY; dy++)
+        {
+            for (int dx = dMinX; dx <= dMaxX; dx++)
+            {
+                double px = dx - ox - cx;
+                double py = dy - oy - cy;
+
+                // Inverse rotation R(-twist).
+                double sxf = cos * px + sin * py + cx;
+                double syf = -sin * px + cos * py + cy;
+
+                // Standard nearest-neighbor rounding (Math.Round would use banker's rounding and
+                // could drop pixels asymmetrically at .5 boundaries during rotation).
+                int sxi = (int)Math.Floor(sxf + 0.5);
+                int syi = (int)Math.Floor(syf + 0.5);
+
+                if (sxi < 0 || sxi >= width || syi < 0 || syi >= height)
+                    continue;
+
+                int srcIdx = syi * width + sxi;
+                if (_labels[srcIdx] != label)
+                    continue;
+
+                dst.Add(dy * width + dx);
+                src.Add(srcIdx);
+            }
+        }
+
+        return new ManipulatedTile
+        {
+            Label = label,
+            DstOffsets = dst.ToArray(),
+            SrcOffsets = src.ToArray()
+        };
+    }
+
+    // Finalizes the manual moves/rotations collected during BuildSelection:
+    //   1) reorders so the active tile is processed last (so it wins overlaps / draws on top),
+    //   2) adds each transformed footprint to the selection so shadows, edges and the final mask
+    //      follow the new position (underfilling has already run, so it can't eat a placed tile),
+    //   3) punches the manipulated tiles' original pixels out of the manual label map (the holes
+    //      they left), then stamps the transformed footprints in. Punching for all tiles before
+    //      stamping prevents a footprint that lands on another tile's vacated pixels from being
+    //      cleared again.
+    private void ApplyManipulatedTiles(List<TileSegment> tileSegments, bool[] selection)
+    {
+        if (_manipulatedTiles.Count == 0)
+            return;
+
+        int activeLabel = ActiveManipulatedTileLabel;
+        if (activeLabel > 0)
+        {
+            int activeIdx = _manipulatedTiles.FindIndex(t => t.Label == activeLabel);
+            if (activeIdx >= 0 && activeIdx != _manipulatedTiles.Count - 1)
+            {
+                var active = _manipulatedTiles[activeIdx];
+                _manipulatedTiles.RemoveAt(activeIdx);
+                _manipulatedTiles.Add(active);
+            }
+        }
+
+        foreach (var tile in _manipulatedTiles)
+        {
+            int[] dst = tile.DstOffsets;
+            for (int i = 0; i < dst.Length; i++)
+                selection[dst[i]] = true;
+        }
+
+        if (_manualLabels.Length != Width * Height)
+            return;
+
+        foreach (var tile in _manipulatedTiles)
+        {
+            var original = tileSegments[tile.Label - 1].PixelOffsets;
+            foreach (int off in original)
+                _manualLabels[off] = 0;
+        }
+
+        foreach (var tile in _manipulatedTiles)
+        {
+            int[] dst = tile.DstOffsets;
+            for (int i = 0; i < dst.Length; i++)
+                _manualLabels[dst[i]] = tile.Label;
+        }
     }
 
     private void SubstractUnderfilled(bool[] selection, byte[] tilePixels)

--- a/TgaBuilderLib/Transitions/TransitionHelper.Buffers.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.Buffers.cs
@@ -33,6 +33,12 @@ public partial class TransitionHelper
         _scratchShadowedBg = new byte[n4];
         _scratchLabelMap = new byte[n4];
         _edgeDist = new int[n];
+        _manualLabels = new int[n];
+
+        // The tile set changes with the picture size, so any pending manual move/rotate state
+        // no longer maps to a valid tile and must be dropped.
+        _manipulatedTiles.Clear();
+        ActiveManipulatedTileLabel = 0;
 
         Width = width;
         Height = height;

--- a/TgaBuilderLib/Transitions/TransitionHelper.Export.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.Export.cs
@@ -47,6 +47,24 @@ public partial class TransitionHelper
             // The other buffer stays fully transparent (all zero) at this pixel.
         }
 
+        // Manually moved/rotated tiles are selected at their new positions, where the loop above
+        // copied the wrong (static) source pixels. Repaint their true content from the original
+        // source pixels so the exported "Bricks" layer matches the on-screen result.
+        foreach (var tile in _manipulatedTiles)
+        {
+            int[] dst = tile.DstOffsets;
+            int[] src = tile.SrcOffsets;
+            for (int i = 0; i < dst.Length; i++)
+            {
+                int d = dst[i] * TRANSITIONS_BPP;
+                int s = src[i] * TRANSITIONS_BPP;
+                selected[d + 0] = Pixels1[s + 0];
+                selected[d + 1] = Pixels1[s + 1];
+                selected[d + 2] = Pixels1[s + 2];
+                selected[d + 3] = Pixels1[s + 3];
+            }
+        }
+
         return new[]
         {
             new TransitionExportLayer(background, Width, Height, "Background", true),

--- a/TgaBuilderLib/Transitions/TransitionHelper.cs
+++ b/TgaBuilderLib/Transitions/TransitionHelper.cs
@@ -34,6 +34,14 @@ public partial class TransitionHelper : ITransitionHelper
     // Per-pixel Chebyshev distance to the nearest opposite-selection pixel, precomputed once
     // per selection change and reused by both shadow and edge drawing passes.
     private int[] _edgeDist = Array.Empty<int>();
+    // "Current occupancy" label map: like _labels, but reflecting manual tile moves/rotations
+    // (holes where a tile left, relocated footprints where it went). Drives tile picking and the
+    // hover indicator so they follow the manual adjustments; the colored debug label map
+    // (GetLabelMap) keeps using the untouched _labels.
+    private int[] _manualLabels = Array.Empty<int>();
+    // User-manipulated (moved and/or rotated) tiles, recomputed by BuildSelection whenever the
+    // manipulation state changes and drawn as an overlay on top of the base result by BricksDraw.
+    private readonly List<ManipulatedTile> _manipulatedTiles = new();
 
     private bool _labelsBuilt;
     private bool _selectionBuilt;
@@ -76,6 +84,9 @@ public partial class TransitionHelper : ITransitionHelper
     public Color ShadowColor { get; set; } = new Color(42, 42, 42, 42);
     public int ShadowSize { get; set; } = 3;
     public int ShadowHardness { get; set; } = 50;
+    // Label of the tile the user is currently moving/rotating. Drawn and stamped last so it ends
+    // up on top of any other manipulated tiles it overlaps. 0 means "none".
+    public int ActiveManipulatedTileLabel { get; set; }
     public event EventHandler? RecalculationCompleted;
     public void Mix()
     {
@@ -100,6 +111,9 @@ public partial class TransitionHelper : ITransitionHelper
         _scratchShadowedBg = Array.Empty<byte>();
         _scratchLabelMap = Array.Empty<byte>();
         _edgeDist = Array.Empty<int>();
+        _manualLabels = Array.Empty<int>();
+        _manipulatedTiles.Clear();
+        ActiveManipulatedTileLabel = 0;
 
         _labelsBuilt = false;
         _selectionBuilt = false;
@@ -143,4 +157,15 @@ public partial class TransitionHelper : ITransitionHelper
         UnderfillingThreshold = 0;
     }
 
+    // A user-manipulated (moved and/or rotated) tile. The two parallel arrays map every
+    // destination pixel offset the tile now covers (DstOffsets) to the source pixel offset it
+    // samples from the original, un-manipulated tile image (SrcOffsets). Computed once per
+    // selection rebuild via inverse mapping so the footprint used for the selection, the manual
+    // label map and the color overlay are guaranteed identical.
+    private struct ManipulatedTile
+    {
+        public int Label;
+        public int[] DstOffsets;
+        public int[] SrcOffsets;
+    }
 }

--- a/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
@@ -96,18 +96,24 @@ public class TransitionOutViewModel : ThrottledViewModelBase
     private bool _isExplicitTileVisibilityDrawMode;
     private bool _isExplicitTileVisibilityEraseMode;
     private bool _isTileMoveRotateMode;
+    private bool _isTileRotateMode;
 
     // Rotation applied per mouse-wheel notch, in degrees. The wheel gives discrete steps; the tile
     // can still reach any angle by accumulating notches.
     private const float RotationStepDegrees = 5f;
 
-    // Drag/rotate target state. _activeManipulationLabel is the tile the user grabbed (and the
-    // wheel rotation target); the rest anchor a drag to the tile's offset at grab time.
+    // Degrees of rotation applied per pixel of horizontal drag in the dedicated rotate-only mode.
+    private const float RotateDragDegreesPerPixel = 1f;
+
+    // Drag/rotate target state. _activeManipulationLabel is the tile the user grabbed or last set
+    // visible (the wheel/rotate target); the rest anchor a drag to the tile's offset/angle at grab
+    // time.
     private int _activeManipulationLabel;
     private int _dragStartX;
     private int _dragStartY;
     private int _dragBaseOffsetX;
     private int _dragBaseOffsetY;
+    private float _dragBaseTwist;
 
 
     public bool IsExplicitTileVisibilityDrawMode
@@ -117,17 +123,10 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         {
             SetProperty(ref _isExplicitTileVisibilityDrawMode, value, nameof(IsExplicitTileVisibilityDrawMode));
             OnPropertyChanged(nameof(IsAnyManualMode));
+            OnPropertyChanged(nameof(IsWheelRotationMode));
 
-            if (!value)
-                return;
-
-            _isExplicitTileVisibilityEraseMode = false;
-            OnPropertyChanged(nameof(IsExplicitTileVisibilityEraseMode));
-
-            _isTileMoveRotateMode = false;
-            OnPropertyChanged(nameof(IsTileMoveRotateMode));
-
-            EndActiveManipulation();
+            if (value)
+                DisableManualModesExcept(nameof(IsExplicitTileVisibilityDrawMode));
         }
     }
 
@@ -138,17 +137,10 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         {
             SetProperty(ref _isExplicitTileVisibilityEraseMode, value, nameof(IsExplicitTileVisibilityEraseMode));
             OnPropertyChanged(nameof(IsAnyManualMode));
+            OnPropertyChanged(nameof(IsWheelRotationMode));
 
-            if (!value)
-                return;
-
-            _isExplicitTileVisibilityDrawMode = false;
-            OnPropertyChanged(nameof(IsExplicitTileVisibilityDrawMode));
-
-            _isTileMoveRotateMode = false;
-            OnPropertyChanged(nameof(IsTileMoveRotateMode));
-
-            EndActiveManipulation();
+            if (value)
+                DisableManualModesExcept(nameof(IsExplicitTileVisibilityEraseMode));
         }
     }
 
@@ -159,25 +151,70 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         {
             SetProperty(ref _isTileMoveRotateMode, value, nameof(IsTileMoveRotateMode));
             OnPropertyChanged(nameof(IsAnyManualMode));
+            OnPropertyChanged(nameof(IsWheelRotationMode));
 
-            if (!value)
-            {
+            if (value)
+                DisableManualModesExcept(nameof(IsTileMoveRotateMode));
+            else
                 EndActiveManipulation();
-                return;
-            }
-
-            _isExplicitTileVisibilityDrawMode = false;
-            OnPropertyChanged(nameof(IsExplicitTileVisibilityDrawMode));
-
-            _isExplicitTileVisibilityEraseMode = false;
-            OnPropertyChanged(nameof(IsExplicitTileVisibilityEraseMode));
         }
     }
 
-    // True while any of the manual single-tile modes (draw / erase / move-rotate) is active. The
-    // views use it to decide whether to show the hover indicator and route pointer interactions.
+    public bool IsTileRotateMode
+    {
+        get => _isTileRotateMode;
+        set
+        {
+            SetProperty(ref _isTileRotateMode, value, nameof(IsTileRotateMode));
+            OnPropertyChanged(nameof(IsAnyManualMode));
+            OnPropertyChanged(nameof(IsWheelRotationMode));
+
+            if (value)
+                DisableManualModesExcept(nameof(IsTileRotateMode));
+            else
+                EndActiveManipulation();
+        }
+    }
+
+    // Turns off every manual mode except the named one and releases any active manipulation, so the
+    // toggles stay mutually exclusive. Sets backing fields directly to avoid re-entering setters.
+    private void DisableManualModesExcept(string keep)
+    {
+        if (keep != nameof(IsExplicitTileVisibilityDrawMode) && _isExplicitTileVisibilityDrawMode)
+        {
+            _isExplicitTileVisibilityDrawMode = false;
+            OnPropertyChanged(nameof(IsExplicitTileVisibilityDrawMode));
+        }
+        if (keep != nameof(IsExplicitTileVisibilityEraseMode) && _isExplicitTileVisibilityEraseMode)
+        {
+            _isExplicitTileVisibilityEraseMode = false;
+            OnPropertyChanged(nameof(IsExplicitTileVisibilityEraseMode));
+        }
+        if (keep != nameof(IsTileMoveRotateMode) && _isTileMoveRotateMode)
+        {
+            _isTileMoveRotateMode = false;
+            OnPropertyChanged(nameof(IsTileMoveRotateMode));
+        }
+        if (keep != nameof(IsTileRotateMode) && _isTileRotateMode)
+        {
+            _isTileRotateMode = false;
+            OnPropertyChanged(nameof(IsTileRotateMode));
+        }
+
+        EndActiveManipulation();
+    }
+
+    // True while any of the manual single-tile modes (draw / erase / move-rotate / rotate) is
+    // active. The views use it to decide whether to show the hover indicator and route pointer
+    // interactions.
     public bool IsAnyManualMode =>
-        _isExplicitTileVisibilityDrawMode || _isExplicitTileVisibilityEraseMode || _isTileMoveRotateMode;
+        _isExplicitTileVisibilityDrawMode || _isExplicitTileVisibilityEraseMode
+        || _isTileMoveRotateMode || _isTileRotateMode;
+
+    // True in the modes where the mouse wheel rotates the active tile: the visibility pen (rotates
+    // the latest tile set visible), move-rotate, and the dedicated rotate-only mode.
+    public bool IsWheelRotationMode =>
+        _isExplicitTileVisibilityDrawMode || _isTileMoveRotateMode || _isTileRotateMode;
 
 
     // =====================================================================
@@ -244,9 +281,9 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         if (ResultImage.PixelWidth <= 0 || ResultImage.PixelHeight <= 0)
             return;
 
-        // In move-rotate mode only highlight tiles that can actually be grabbed (protected edge
-        // tiles read as none), giving the user clear feedback about what is movable.
-        int label = _isTileMoveRotateMode
+        // In move/rotate modes only highlight tiles that can actually be grabbed (protected edge
+        // tiles read as none), giving the user clear feedback about what is manipulable.
+        int label = (_isTileMoveRotateMode || _isTileRotateMode)
             ? _transitionHelper.PickManipulableTileAt(x, y)
             : _transitionHelper.GetLabelAtPixel(x, y);
 
@@ -284,19 +321,33 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         if (label == 0)
             return;
 
-        bool visibilityChanged = _transitionHelper.SetExplicitTileVisibility(label, IsExplicitTileVisibilityDrawMode);
+        if (_isExplicitTileVisibilityDrawMode)
+        {
+            // The latest tile set visible with the pen becomes the wheel-rotation target and is
+            // drawn on top of other manipulated tiles.
+            _activeManipulationLabel = label;
+            _transitionHelper.ActiveManipulatedTileLabel = label;
+        }
+        else if (_activeManipulationLabel == label)
+        {
+            // Erasing the active tile clears the rotation target (it is also reset to its original
+            // position/rotation by the helper).
+            _activeManipulationLabel = 0;
+        }
 
-        _transitionHelper.CurrentBricksPipelineRequirements 
+        bool changed = _transitionHelper.SetExplicitTileVisibility(label, _isExplicitTileVisibilityDrawMode);
+
+        _transitionHelper.CurrentBricksPipelineRequirements
         = BricksPipelineRequirements.RequiresSelectionBuilding;
 
-        if (!visibilityChanged)
+        if (!changed)
             return;
 
         _ = TriggerRecalculation();
     }
 
-    // Pointer pressed in the result image. Draw/erase modes toggle tile visibility; move-rotate
-    // mode grabs the tile under the cursor as the active manipulation/rotation target.
+    // Pointer pressed in the result image. Draw/erase modes toggle tile visibility; move and
+    // rotate modes grab the tile under the cursor as the active manipulation/rotation target.
     private void ManualPointerDown(int x, int y)
     {
         if (_isTileMoveRotateMode)
@@ -305,17 +356,29 @@ public class TransitionOutViewModel : ThrottledViewModelBase
             return;
         }
 
+        if (_isTileRotateMode)
+        {
+            BeginRotation(x, y);
+            return;
+        }
+
         if (_isExplicitTileVisibilityDrawMode || _isExplicitTileVisibilityEraseMode)
             SetExplicitTileVisibility(x, y);
     }
 
-    // Pointer dragged (left button held). Draw/erase keep toggling along the path; move-rotate
-    // drags the grabbed tile by the cursor delta.
+    // Pointer dragged (left button held). Draw/erase keep toggling along the path; move drags the
+    // grabbed tile by the cursor delta; rotate spins it by the horizontal drag distance.
     private void ManualPointerDrag(int x, int y)
     {
         if (_isTileMoveRotateMode)
         {
             DragActiveTile(x, y);
+            return;
+        }
+
+        if (_isTileRotateMode)
+        {
+            DragRotateActiveTile(x, y);
             return;
         }
 
@@ -338,6 +401,21 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         _dragStartY = y;
     }
 
+    private void BeginRotation(int x, int y)
+    {
+        int label = _transitionHelper.PickManipulableTileAt(x, y);
+
+        _activeManipulationLabel = label;
+        _transitionHelper.ActiveManipulatedTileLabel = label;
+
+        if (label == 0)
+            return;
+
+        _dragBaseTwist = _transitionHelper.GetTileTwist(label);
+        _dragStartX = x;
+        _dragStartY = y;
+    }
+
     private void DragActiveTile(int x, int y)
     {
         if (_activeManipulationLabel == 0)
@@ -355,15 +433,36 @@ public class TransitionOutViewModel : ThrottledViewModelBase
             _ = TriggerRecalculation();
     }
 
-    private void RotateActiveTile(int x, int y, int notches)
+    private void DragRotateActiveTile(int x, int y)
     {
-        if (!_isTileMoveRotateMode || notches == 0)
+        if (_activeManipulationLabel == 0)
             return;
 
-        // Without a grabbed tile (scrolling over a tile without clicking first), adopt the tile
-        // under the cursor as the active rotation target.
+        // Distance-based rotation: horizontal drag from the grab point maps to an absolute angle
+        // (anchored to the tile's angle at grab time), so dragging back unwinds the rotation.
+        float angle = _dragBaseTwist + (x - _dragStartX) * RotateDragDegreesPerPixel;
+
+        bool changed = _transitionHelper.SetTileTwist(_activeManipulationLabel, angle);
+
+        _transitionHelper.CurrentBricksPipelineRequirements
+            = BricksPipelineRequirements.RequiresSelectionBuilding;
+
+        if (changed)
+            _ = TriggerRecalculation();
+    }
+
+    private void RotateActiveTile(int x, int y, int notches)
+    {
+        if (!IsWheelRotationMode || notches == 0)
+            return;
+
         if (_activeManipulationLabel == 0)
         {
+            // In move/rotate modes, adopt the tile under the cursor (scrolling without grabbing
+            // first). In pen mode the wheel only rotates the latest tile set visible — no fallback.
+            if (!_isTileMoveRotateMode && !_isTileRotateMode)
+                return;
+
             int label = _transitionHelper.PickManipulableTileAt(x, y);
             if (label == 0)
                 return;
@@ -418,6 +517,7 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         IsExplicitTileVisibilityDrawMode = false;
         IsExplicitTileVisibilityEraseMode = false;
         IsTileMoveRotateMode = false;
+        IsTileRotateMode = false;
         EndActiveManipulation();
     }
 

--- a/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
+++ b/TgaBuilderLib/ViewModel/Transitions/TransitionOutViewModel.cs
@@ -95,6 +95,19 @@ public class TransitionOutViewModel : ThrottledViewModelBase
 
     private bool _isExplicitTileVisibilityDrawMode;
     private bool _isExplicitTileVisibilityEraseMode;
+    private bool _isTileMoveRotateMode;
+
+    // Rotation applied per mouse-wheel notch, in degrees. The wheel gives discrete steps; the tile
+    // can still reach any angle by accumulating notches.
+    private const float RotationStepDegrees = 5f;
+
+    // Drag/rotate target state. _activeManipulationLabel is the tile the user grabbed (and the
+    // wheel rotation target); the rest anchor a drag to the tile's offset at grab time.
+    private int _activeManipulationLabel;
+    private int _dragStartX;
+    private int _dragStartY;
+    private int _dragBaseOffsetX;
+    private int _dragBaseOffsetY;
 
 
     public bool IsExplicitTileVisibilityDrawMode
@@ -103,12 +116,18 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         set
         {
             SetProperty(ref _isExplicitTileVisibilityDrawMode, value, nameof(IsExplicitTileVisibilityDrawMode));
+            OnPropertyChanged(nameof(IsAnyManualMode));
 
             if (!value)
                 return;
 
             _isExplicitTileVisibilityEraseMode = false;
             OnPropertyChanged(nameof(IsExplicitTileVisibilityEraseMode));
+
+            _isTileMoveRotateMode = false;
+            OnPropertyChanged(nameof(IsTileMoveRotateMode));
+
+            EndActiveManipulation();
         }
     }
 
@@ -118,13 +137,47 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         set
         {
             SetProperty(ref _isExplicitTileVisibilityEraseMode, value, nameof(IsExplicitTileVisibilityEraseMode));
+            OnPropertyChanged(nameof(IsAnyManualMode));
+
             if (!value)
                 return;
 
             _isExplicitTileVisibilityDrawMode = false;
             OnPropertyChanged(nameof(IsExplicitTileVisibilityDrawMode));
+
+            _isTileMoveRotateMode = false;
+            OnPropertyChanged(nameof(IsTileMoveRotateMode));
+
+            EndActiveManipulation();
         }
     }
+
+    public bool IsTileMoveRotateMode
+    {
+        get => _isTileMoveRotateMode;
+        set
+        {
+            SetProperty(ref _isTileMoveRotateMode, value, nameof(IsTileMoveRotateMode));
+            OnPropertyChanged(nameof(IsAnyManualMode));
+
+            if (!value)
+            {
+                EndActiveManipulation();
+                return;
+            }
+
+            _isExplicitTileVisibilityDrawMode = false;
+            OnPropertyChanged(nameof(IsExplicitTileVisibilityDrawMode));
+
+            _isExplicitTileVisibilityEraseMode = false;
+            OnPropertyChanged(nameof(IsExplicitTileVisibilityEraseMode));
+        }
+    }
+
+    // True while any of the manual single-tile modes (draw / erase / move-rotate) is active. The
+    // views use it to decide whether to show the hover indicator and route pointer interactions.
+    public bool IsAnyManualMode =>
+        _isExplicitTileVisibilityDrawMode || _isExplicitTileVisibilityEraseMode || _isTileMoveRotateMode;
 
 
     // =====================================================================
@@ -134,6 +187,10 @@ public class TransitionOutViewModel : ThrottledViewModelBase
     private RelayCommand<(int, int)>? _setExplicitTileVisibilityCommand;
     private RelayCommand? _resetExplicitVisibilityCommand;
     private RelayCommand<(int, int)>? _requestLabelIndicatorCommand;
+    private RelayCommand<(int, int)>? _manualPointerDownCommand;
+    private RelayCommand<(int, int)>? _manualPointerDragCommand;
+    private RelayCommand<(int, int, int)>? _rotateActiveTileCommand;
+    private RelayCommand? _endManipulationCommand;
 
 
     public ICommand SetExplicitTileVisibilityCommand => _setExplicitTileVisibilityCommand
@@ -143,6 +200,18 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         ??= new RelayCommand(ResetAllExplicitTileVisibility);
     public ICommand RequestLabelIndicatorCommand => _requestLabelIndicatorCommand
         ??= new RelayCommand<(int, int)>(args => RequestNewIndicatorMapImage(args.Item1, args.Item2));
+
+    // Routes a pointer press / drag in the result image to the active manual mode: visibility
+    // draw/erase, or begin/continue a tile move.
+    public ICommand ManualPointerDownCommand => _manualPointerDownCommand
+        ??= new RelayCommand<(int, int)>(args => ManualPointerDown(args.Item1, args.Item2));
+    public ICommand ManualPointerDragCommand => _manualPointerDragCommand
+        ??= new RelayCommand<(int, int)>(args => ManualPointerDrag(args.Item1, args.Item2));
+    // (x, y, notches) — rotates the active (or hovered) tile in move-rotate mode.
+    public ICommand RotateActiveTileCommand => _rotateActiveTileCommand
+        ??= new RelayCommand<(int, int, int)>(args => RotateActiveTile(args.Item1, args.Item2, args.Item3));
+    public ICommand EndManipulationCommand => _endManipulationCommand
+        ??= new RelayCommand(EndActiveManipulation);
 
 
 
@@ -175,7 +244,11 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         if (ResultImage.PixelWidth <= 0 || ResultImage.PixelHeight <= 0)
             return;
 
-        int label = _transitionHelper.GetLabelAtPixel(x, y);
+        // In move-rotate mode only highlight tiles that can actually be grabbed (protected edge
+        // tiles read as none), giving the user clear feedback about what is movable.
+        int label = _isTileMoveRotateMode
+            ? _transitionHelper.PickManipulableTileAt(x, y)
+            : _transitionHelper.GetLabelAtPixel(x, y);
 
         if (label == 0)
             return;
@@ -222,9 +295,103 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         _ = TriggerRecalculation();
     }
 
+    // Pointer pressed in the result image. Draw/erase modes toggle tile visibility; move-rotate
+    // mode grabs the tile under the cursor as the active manipulation/rotation target.
+    private void ManualPointerDown(int x, int y)
+    {
+        if (_isTileMoveRotateMode)
+        {
+            BeginManipulation(x, y);
+            return;
+        }
+
+        if (_isExplicitTileVisibilityDrawMode || _isExplicitTileVisibilityEraseMode)
+            SetExplicitTileVisibility(x, y);
+    }
+
+    // Pointer dragged (left button held). Draw/erase keep toggling along the path; move-rotate
+    // drags the grabbed tile by the cursor delta.
+    private void ManualPointerDrag(int x, int y)
+    {
+        if (_isTileMoveRotateMode)
+        {
+            DragActiveTile(x, y);
+            return;
+        }
+
+        if (_isExplicitTileVisibilityDrawMode || _isExplicitTileVisibilityEraseMode)
+            SetExplicitTileVisibility(x, y);
+    }
+
+    private void BeginManipulation(int x, int y)
+    {
+        int label = _transitionHelper.PickManipulableTileAt(x, y);
+
+        _activeManipulationLabel = label;
+        _transitionHelper.ActiveManipulatedTileLabel = label;
+
+        if (label == 0)
+            return;
+
+        (_dragBaseOffsetX, _dragBaseOffsetY) = _transitionHelper.GetTileOffset(label);
+        _dragStartX = x;
+        _dragStartY = y;
+    }
+
+    private void DragActiveTile(int x, int y)
+    {
+        if (_activeManipulationLabel == 0)
+            return;
+
+        int offsetX = _dragBaseOffsetX + (x - _dragStartX);
+        int offsetY = _dragBaseOffsetY + (y - _dragStartY);
+
+        bool changed = _transitionHelper.MoveTile(_activeManipulationLabel, offsetX, offsetY);
+
+        _transitionHelper.CurrentBricksPipelineRequirements
+            = BricksPipelineRequirements.RequiresSelectionBuilding;
+
+        if (changed)
+            _ = TriggerRecalculation();
+    }
+
+    private void RotateActiveTile(int x, int y, int notches)
+    {
+        if (!_isTileMoveRotateMode || notches == 0)
+            return;
+
+        // Without a grabbed tile (scrolling over a tile without clicking first), adopt the tile
+        // under the cursor as the active rotation target.
+        if (_activeManipulationLabel == 0)
+        {
+            int label = _transitionHelper.PickManipulableTileAt(x, y);
+            if (label == 0)
+                return;
+
+            _activeManipulationLabel = label;
+            _transitionHelper.ActiveManipulatedTileLabel = label;
+        }
+
+        bool changed = _transitionHelper.RotateTileBy(_activeManipulationLabel, notches * RotationStepDegrees);
+
+        _transitionHelper.CurrentBricksPipelineRequirements
+            = BricksPipelineRequirements.RequiresSelectionBuilding;
+
+        if (changed)
+            _ = TriggerRecalculation();
+    }
+
+    private void EndActiveManipulation()
+    {
+        // Releases the wheel-rotation target. The helper keeps its ActiveManipulatedTileLabel so
+        // the last-moved tile stays on top until another tile is grabbed or a reset occurs.
+        _activeManipulationLabel = 0;
+    }
+
     private void ResetAllExplicitTileVisibility()
     {
         _transitionHelper.ResetAllExplicitTileVisibility();
+        EndActiveManipulation();
 
         _transitionHelper.CurrentBricksPipelineRequirements
             = BricksPipelineRequirements.RequiresSelectionBuilding;
@@ -250,6 +417,8 @@ public class TransitionOutViewModel : ThrottledViewModelBase
         IsLabelMapExpanded = false;
         IsExplicitTileVisibilityDrawMode = false;
         IsExplicitTileVisibilityEraseMode = false;
+        IsTileMoveRotateMode = false;
+        EndActiveManipulation();
     }
 
 

--- a/TgaBuilderWpfUi/View/TransitionWindow.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindow.xaml
@@ -306,11 +306,12 @@
                                 x:Name="ResultImage"
                                 RenderOptions.BitmapScalingMode="NearestNeighbor"
                             Source="{Binding TransitionOutVM.ResultImage, Converter={StaticResource WriteableBitmapConverter}}"
-                                Stretch="Uniform" 
+                                Stretch="Uniform"
                                 MouseMove="ResultImage_MouseMove"
                                 MouseEnter="ResultImage_MouseEnter"
                                 MouseLeave="ResultImage_MouseLeave"
-                                MouseDown="ResultImage_MouseDown"/>
+                                MouseDown="ResultImage_MouseDown"
+                                MouseWheel="ResultImage_MouseWheel"/>
                             <Image
                                 x:Name="IndicatorImage"
                                 RenderOptions.BitmapScalingMode="NearestNeighbor"

--- a/TgaBuilderWpfUi/View/TransitionWindow.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindow.xaml
@@ -311,6 +311,7 @@
                                 MouseEnter="ResultImage_MouseEnter"
                                 MouseLeave="ResultImage_MouseLeave"
                                 MouseDown="ResultImage_MouseDown"
+                                MouseUp="ResultImage_MouseUp"
                                 MouseWheel="ResultImage_MouseWheel"/>
                             <Image
                                 x:Name="IndicatorImage"

--- a/TgaBuilderWpfUi/View/TransitionWindow.xaml.cs
+++ b/TgaBuilderWpfUi/View/TransitionWindow.xaml.cs
@@ -204,7 +204,7 @@ namespace TgaBuilderWpfUi.View
 
             var tpvm = tvm.TransitionOutVM;
 
-            if (!tpvm.IsTileMoveRotateMode)
+            if (!tpvm.IsWheelRotationMode)
                 return;
 
             int notches = e.Delta > 0 ? 1 : (e.Delta < 0 ? -1 : 0);

--- a/TgaBuilderWpfUi/View/TransitionWindow.xaml.cs
+++ b/TgaBuilderWpfUi/View/TransitionWindow.xaml.cs
@@ -151,6 +151,8 @@ namespace TgaBuilderWpfUi.View
 
             if (e.LeftButton == MouseButtonState.Pressed)
                 tpvm.ManualPointerDragCommand.Execute((X: x, Y: y));
+            else if (tpvm.IsTileRotateMode && ResultImage.IsMouseCaptured)
+                ResultImage.ReleaseMouseCapture();
         }
 
         private void ResultImage_MouseEnter(object sender, MouseEventArgs e)
@@ -177,7 +179,14 @@ namespace TgaBuilderWpfUi.View
                 return;
 
             tpvm.IsIndicatorMapVisible = false;
-            tpvm.EndManipulationCommand.Execute(null);
+
+            if (tpvm.IsTileMoveRotateMode || tpvm.IsTileRotateMode)
+            {
+                if (tpvm.IsTileRotateMode && ResultImage.IsMouseCaptured)
+                    return;
+
+                tpvm.EndManipulationCommand.Execute(null);
+            }
         }
 
         private void ResultImage_MouseDown(object sender, MouseButtonEventArgs e)
@@ -195,6 +204,20 @@ namespace TgaBuilderWpfUi.View
 
             var position = e.GetPosition(ResultImage);
             tpvm.ManualPointerDownCommand.Execute((X: (int)position.X, Y: (int)position.Y));
+
+            if (tpvm.IsTileRotateMode)
+                ResultImage.CaptureMouse();
+        }
+
+        private void ResultImage_MouseUp(object sender, MouseButtonEventArgs e)
+        {
+            if (DataContext is not TransitionViewModel tvm)
+                return;
+
+            var tpvm = tvm.TransitionOutVM;
+
+            if (tpvm.IsTileRotateMode && ResultImage.IsMouseCaptured)
+                ResultImage.ReleaseMouseCapture();
         }
 
         private void ResultImage_MouseWheel(object sender, MouseWheelEventArgs e)

--- a/TgaBuilderWpfUi/View/TransitionWindow.xaml.cs
+++ b/TgaBuilderWpfUi/View/TransitionWindow.xaml.cs
@@ -140,14 +140,17 @@ namespace TgaBuilderWpfUi.View
 
             var tpvm = tvm.TransitionOutVM;
 
-            if (!tpvm.IsExplicitTileVisibilityDrawMode && !tpvm.IsExplicitTileVisibilityEraseMode)
+            if (!tpvm.IsAnyManualMode)
                 return;
 
-            if (tpvm.RequestLabelIndicatorCommand is ICommand requestLabelIndicatorCommand)
-                requestLabelIndicatorCommand.Execute((X: (int)e.GetPosition(ResultImage).X, Y: (int)e.GetPosition(ResultImage).Y));
+            var position = e.GetPosition(ResultImage);
+            int x = (int)position.X;
+            int y = (int)position.Y;
 
-            if (e.LeftButton == MouseButtonState.Pressed && tpvm.SetExplicitTileVisibilityCommand is ICommand setExplicitTileVisibilityCommand)
-                setExplicitTileVisibilityCommand.Execute((X: (int)e.GetPosition(ResultImage).X, Y: (int)e.GetPosition(ResultImage).Y));
+            tpvm.RequestLabelIndicatorCommand.Execute((X: x, Y: y));
+
+            if (e.LeftButton == MouseButtonState.Pressed)
+                tpvm.ManualPointerDragCommand.Execute((X: x, Y: y));
         }
 
         private void ResultImage_MouseEnter(object sender, MouseEventArgs e)
@@ -157,7 +160,7 @@ namespace TgaBuilderWpfUi.View
 
             var tpvm = tvm.TransitionOutVM;
 
-            if (!tpvm.IsExplicitTileVisibilityDrawMode && !tpvm.IsExplicitTileVisibilityEraseMode)
+            if (!tpvm.IsAnyManualMode)
                 return;
 
             tpvm.IsIndicatorMapVisible = true;
@@ -170,10 +173,11 @@ namespace TgaBuilderWpfUi.View
 
             var tpvm = tvm.TransitionOutVM;
 
-            if (!tpvm.IsExplicitTileVisibilityDrawMode && !tpvm.IsExplicitTileVisibilityEraseMode)
+            if (!tpvm.IsAnyManualMode)
                 return;
 
             tpvm.IsIndicatorMapVisible = false;
+            tpvm.EndManipulationCommand.Execute(null);
         }
 
         private void ResultImage_MouseDown(object sender, MouseButtonEventArgs e)
@@ -183,11 +187,35 @@ namespace TgaBuilderWpfUi.View
 
             var tpvm = tvm.TransitionOutVM;
 
-            if (!tpvm.IsExplicitTileVisibilityDrawMode && !tpvm.IsExplicitTileVisibilityEraseMode)
+            if (!tpvm.IsAnyManualMode)
                 return;
 
-            if (e.LeftButton == MouseButtonState.Pressed && tpvm.SetExplicitTileVisibilityCommand is ICommand setExplicitTileVisibilityCommand)
-                setExplicitTileVisibilityCommand.Execute((X: (int)e.GetPosition(ResultImage).X, Y: (int)e.GetPosition(ResultImage).Y));
+            if (e.LeftButton != MouseButtonState.Pressed)
+                return;
+
+            var position = e.GetPosition(ResultImage);
+            tpvm.ManualPointerDownCommand.Execute((X: (int)position.X, Y: (int)position.Y));
+        }
+
+        private void ResultImage_MouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if (DataContext is not TransitionViewModel tvm)
+                return;
+
+            var tpvm = tvm.TransitionOutVM;
+
+            if (!tpvm.IsTileMoveRotateMode)
+                return;
+
+            int notches = e.Delta > 0 ? 1 : (e.Delta < 0 ? -1 : 0);
+            if (notches == 0)
+                return;
+
+            var position = e.GetPosition(ResultImage);
+            tpvm.RotateActiveTileCommand.Execute((X: (int)position.X, Y: (int)position.Y, Notches: notches));
+
+            // Prevent the wheel from also scrolling/zooming the surrounding UI while rotating.
+            e.Handled = true;
         }
     }
 }

--- a/TgaBuilderWpfUi/View/TransitionWindowManualUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowManualUserControl.xaml
@@ -25,7 +25,7 @@
                                 Margin="8,6,8,8">
         <elements:ToggleButtonEx
                                     VerticalAlignment="Center"
-                                    ap:MouseOverInfoAP.InfoText="Reverse the pivot direction"
+                                    ap:MouseOverInfoAP.InfoText="Enable manual drawing of visible tiles"
                                     Icon="{ui:SymbolIcon Pen24}"
                                     MinHeight="36"
                                     MinWidth="36"
@@ -37,15 +37,23 @@
                                     MinHeight="36"
                                     MinWidth="36"
                                     Icon="{ui:SymbolIcon Eraser24}"
-                                    ap:MouseOverInfoAP.InfoText="Protect Edges: Enabling ensures that tile texture bordering edges contains tiles and background bordering edges do not contain tiles."
+                                    ap:MouseOverInfoAP.InfoText="Enable manual erasing of visible tiles"
                                     IsChecked="{Binding IsExplicitTileVisibilityEraseMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <elements:ToggleButtonEx
+                                    Margin="8,0,0,0"
+                                    VerticalAlignment="Center"
+                                    MinHeight="36"
+                                    MinWidth="36"
+                                    Icon="{ui:SymbolIcon ArrowMove24}"
+                                    ap:MouseOverInfoAP.InfoText="Move tiles by dragging and rotate them with the mouse wheel"
+                                    IsChecked="{Binding IsTileMoveRotateMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         <ui:Button
                                     VerticalAlignment="Center"
                                     MinHeight="36"
                                     MinWidth="36"
                                     Margin="8,0,0,0"
                                     Icon="{ui:SymbolIcon Backspace24}"
-                                    ap:MouseOverInfoAP.InfoText="Reset Explicit Visibility"
+                                    ap:MouseOverInfoAP.InfoText="Reset all manual adjustments (visibility, moves and rotations)"
                                     Command="{Binding ResetExplicitVisibilityCommand}" />
 
 

--- a/TgaBuilderWpfUi/View/TransitionWindowManualUserControl.xaml
+++ b/TgaBuilderWpfUi/View/TransitionWindowManualUserControl.xaml
@@ -19,43 +19,52 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <StackPanel
+    <WrapPanel
             DataContext="{Binding TransitionOutVM}"
                                 Orientation="Horizontal"
                                 Margin="8,6,8,8">
         <elements:ToggleButtonEx
+                                    Margin="0,0,8,8"
                                     VerticalAlignment="Center"
-                                    ap:MouseOverInfoAP.InfoText="Enable manual drawing of visible tiles"
+                                    ap:MouseOverInfoAP.InfoText="Enable manual drawing of visible tiles. The mouse wheel rotates the last tile set visible."
                                     Icon="{ui:SymbolIcon Pen24}"
                                     MinHeight="36"
                                     MinWidth="36"
                                     IsChecked="{Binding IsExplicitTileVisibilityDrawMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         <elements:ToggleButtonEx
-                                    Margin="8,0,0,0"
+                                    Margin="0,0,8,8"
                                     x:Name="ProtectEdgesToggleButton"
                                     VerticalAlignment="Center"
                                     MinHeight="36"
                                     MinWidth="36"
                                     Icon="{ui:SymbolIcon Eraser24}"
-                                    ap:MouseOverInfoAP.InfoText="Enable manual erasing of visible tiles"
+                                    ap:MouseOverInfoAP.InfoText="Enable manual erasing of visible tiles. Erasing a moved/rotated tile restores its original position and rotation."
                                     IsChecked="{Binding IsExplicitTileVisibilityEraseMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         <elements:ToggleButtonEx
-                                    Margin="8,0,0,0"
+                                    Margin="0,0,8,8"
                                     VerticalAlignment="Center"
                                     MinHeight="36"
                                     MinWidth="36"
                                     Icon="{ui:SymbolIcon ArrowMove24}"
                                     ap:MouseOverInfoAP.InfoText="Move tiles by dragging and rotate them with the mouse wheel"
                                     IsChecked="{Binding IsTileMoveRotateMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        <elements:ToggleButtonEx
+                                    Margin="0,0,8,8"
+                                    VerticalAlignment="Center"
+                                    MinHeight="36"
+                                    MinWidth="36"
+                                    Icon="{ui:SymbolIcon ArrowRotateCounterclockwise24}"
+                                    ap:MouseOverInfoAP.InfoText="Rotate a tile: click it and drag to spin it; the mouse wheel fine-tunes the last rotated tile"
+                                    IsChecked="{Binding IsTileRotateMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         <ui:Button
                                     VerticalAlignment="Center"
                                     MinHeight="36"
                                     MinWidth="36"
-                                    Margin="8,0,0,0"
+                                    Margin="0,0,8,8"
                                     Icon="{ui:SymbolIcon Backspace24}"
                                     ap:MouseOverInfoAP.InfoText="Reset all manual adjustments (visibility, moves and rotations)"
                                     Command="{Binding ResetExplicitVisibilityCommand}" />
 
 
-    </StackPanel>
+    </WrapPanel>
 </UserControl>

--- a/versionUpdate.md
+++ b/versionUpdate.md
@@ -72,7 +72,8 @@ Version 2.2.5 with major transition performance improvements, new controls to ma
 - **Brick / Underfilling** expander: **Pivot** (`0` – `1`) sets the positional bias of the underfilling area.
 - **Brick / Manual** expander (new): **Tile Visibility Pen** toggle — draw on the result image to mark tiles as visible.
 - **Brick / Manual** expander: **Tile Visibility Eraser** toggle — draw on the result image to mark tiles as hidden.
-- **Brick / Manual** expander: **Reset** button clears all manual visibility overrides and reverts to the computed result.
+- **Brick / Manual** expander: **Tile Move & Rotate** toggle — drag a single tile on the result image to reposition it, and use the mouse wheel to freely rotate the grabbed tile around its centroid. Moved/rotated tiles are drawn on top of other tiles, become visible automatically if they were hidden, and leave a hole (reflected by the hover indicator) at their original position. Edge tiles are not movable while edge protection is on.
+- **Brick / Manual** expander: **Reset** button clears all manual adjustments — visibility overrides, moves and rotations — and reverts to the computed result.
 - **Main window / Target panel**: hold **Space** while clicking or dragging to make a free (grid-independent) selection; release Space to return to normal grid-snapped behavior.
 - **Main window (Avalonia UI)**: **Copy / Paste** (`Ctrl+C` / `Ctrl+V`) support added.
 - **Release build lineup changed**: the combined release now ships three packages — `TgaBuilder-Standard-Vx.x.x.zip` (WPF .NET 6, requires .NET 6 runtime), `TgaBuilder-PreviewAvalonia-Windows-Vx.x.x.zip` (Avalonia UI, Windows, self-contained), and `TgaBuilder-PreviewAvalonia-Linux-Vx.x.x.zip` (Avalonia UI, Linux, self-contained). The former separate WPF .NET 8 and non-self-contained Avalonia builds are no longer included.

--- a/versionUpdate.md
+++ b/versionUpdate.md
@@ -70,9 +70,10 @@ Version 2.2.5 with major transition performance improvements, new controls to ma
 - **Brick / Underfilling** expander (new): reverse toggle turns underfilling into overfilling by substituting bright pixels (useful for sandy textures and bright backgrounds).
 - **Brick / Underfilling** expander: **Threshold** (`0` – `255`) sets the underfilling intensity (`0` = none, `255` = maximum).
 - **Brick / Underfilling** expander: **Pivot** (`0` – `1`) sets the positional bias of the underfilling area.
-- **Brick / Manual** expander (new): **Tile Visibility Pen** toggle — draw on the result image to mark tiles as visible.
-- **Brick / Manual** expander: **Tile Visibility Eraser** toggle — draw on the result image to mark tiles as hidden.
-- **Brick / Manual** expander: **Tile Move & Rotate** toggle — drag a single tile on the result image to reposition it, and use the mouse wheel to freely rotate the grabbed tile around its centroid. Moved/rotated tiles are drawn on top of other tiles, become visible automatically if they were hidden, and leave a hole (reflected by the hover indicator) at their original position. Edge tiles are not movable while edge protection is on.
+- **Brick / Manual** expander (new): **Tile Visibility Pen** toggle — draw on the result image to mark tiles as visible. The mouse wheel rotates the last tile that was set visible.
+- **Brick / Manual** expander: **Tile Visibility Eraser** toggle — draw on the result image to mark tiles as hidden. Erasing a moved/rotated tile returns it to its original position and orientation.
+- **Brick / Manual** expander: **Tile Move & Rotate** toggle — drag a single tile on the result image to reposition it, and use the mouse wheel to freely rotate the grabbed tile around its centroid. Moved/rotated tiles are drawn on top of other tiles (with full shadow and edge tinting), become visible automatically if they were hidden, and leave a hole (reflected by the hover indicator) at their original position. Edge tiles are not movable while edge protection is on.
+- **Brick / Manual** expander: **Tile Rotate** toggle — click a tile and drag to spin it (rotation follows the horizontal drag distance); the mouse wheel fine-tunes the last rotated tile.
 - **Brick / Manual** expander: **Reset** button clears all manual adjustments — visibility overrides, moves and rotations — and reverts to the computed result.
 - **Main window / Target panel**: hold **Space** while clicking or dragging to make a free (grid-independent) selection; release Space to return to normal grid-snapped behavior.
 - **Main window (Avalonia UI)**: **Copy / Paste** (`Ctrl+C` / `Ctrl+V`) support added.


### PR DESCRIPTION
## Summary
This PR adds a new "Move/Rotate" mode to the brick transition editor, allowing users to manually reposition and rotate individual tiles in the result image. The feature includes inverse-mapped rotation to avoid holes, proper z-ordering with the active tile drawn on top, and integration with both WPF and Avalonia UI frameworks.

It also refines manual interaction behavior based on review feedback: pen-mode wheel rotation target is preserved across image leave/enter, and rotate-only mode now uses pointer/mouse capture so rotation continues even when the cursor leaves the image area.

## Key Changes

### Core Manipulation Logic
- **TransitionHelper.BricksSelection.cs**: Added `ComputeManipulatedFootprint()` to calculate transformed tile footprints using inverse rotation mapping around the tile's centroid. Added `ApplyManipulatedTiles()` to finalize manual moves/rotations by updating the selection and the occupancy label map.
- **TransitionHelper.BricksManual.cs**: Implemented `PickManipulableTileAt()` to select tiles that can be moved (excluding edge-protected tiles), `MoveTile()` and `RotateTileBy()` for applying transformations, and `GetTileOffset()` to retrieve current tile positions.
- **TransitionHelper.cs**: Added `_manualLabels` occupancy map and `_manipulatedTiles` list to track user-manipulated tiles. Added `ActiveManipulatedTileLabel` property to ensure the active tile is drawn last (on top).

### Rendering
- **TransitionHelper.BricksDraw.cs**: Added `DrawManipulatedTiles()` to repaint transformed tiles over the base result, using source/destination pixel mappings computed during selection building.
- **TransitionHelper.Export.cs**: Updated export layer building to correctly render manipulated tiles in exported "Bricks" layer.

### UI Integration
- **TransitionOutViewModel.cs**: Added `IsTileMoveRotateMode` property and related state tracking (`_activeManipulationLabel`, drag anchors). Implemented `ManualPointerDown()`, `ManualPointerDrag()`, `RotateActiveTile()`, and `EndActiveManipulation()` methods. Added `IsAnyManualMode` computed property to unify visibility/draw/erase/move-rotate mode checks. Integrated new commands: `ManualPointerDownCommand`, `ManualPointerDragCommand`, `RotateActiveTileCommand`, `EndManipulationCommand`.
- **TransitionWindow.xaml.cs (WPF)** and **TransitionWindow.axaml.cs (Avalonia)**: Refactored pointer event handlers to route interactions through the new unified manual mode commands. Added mouse wheel handler for rotation in move-rotate mode.
- **TransitionWindow.xaml.cs (WPF)** and **TransitionWindow.axaml.cs (Avalonia)**: Updated image-leave behavior to only end manipulation for grab-based modes (move/rotate and rotate), so pen-mode wheel target is not cleared on leave.
- **TransitionWindow.xaml.cs (WPF)** and **TransitionWindow.axaml.cs (Avalonia)**: Added rotate-mode-only mouse/pointer capture on press, release on button-up, and safety release when drag is no longer active, ensuring uninterrupted tile rotation outside image bounds.
- **TransitionWindowManualUserControl**: Added toggle button for move-rotate mode with appropriate icon and tooltip.

### Label Map &amp; Picking
- **TransitionHelper.BricksLabelMap.cs**: Added `CurrentLabels` property that returns the occupancy map (`_manualLabels`) when available, allowing tile picking and hover indicators to follow manual repositioning while keeping the debug label map unchanged.

## Implementation Details

- **Inverse Rotation Mapping**: Tiles are rotated by inverse-mapping destination pixels to source pixels, avoiding holes and ensuring each destination pixel is written exactly once.
- **Z-Ordering**: The `ActiveManipulatedTileLabel` ensures the tile being manipulated is drawn last, appearing on top of any overlapping tiles.
- **Occupancy Tracking**: The `_manualLabels` map is updated to punch holes where tiles vacated and stamp relocated footprints, enabling correct picking and visual feedback.
- **Edge Protection**: Tiles touching image borders cannot be picked for manipulation when `ProtectEdges` is enabled, preserving seamless transitions.
- **Rotation Step**: Rotation is applied in 5-degree increments per mouse wheel notch, allowing any angle through accumulation.
- **Rotate Interaction Continuity**: In rotate-only mode, pointer/mouse capture keeps rotation interaction active across image boundary exits until release.

https://claude.ai/code/session_017A1nFxLc4KokXcHPbGrdmC